### PR TITLE
Add fullscreen display controlled from web

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A modular, web-controlled media display application for Linux devices (e.g., Ras
 - Updatable from GitHub
 - SMB share integration
 - Spotify integration (planned)
+- Fullscreen media display controllable from the web UI
 
 ## Getting Started
 
@@ -18,8 +19,9 @@ pip install -r requirements.txt
 ```
 
 ### 2. Run setup (optional)
-Use `./setup.sh` to configure local or SMB media storage and install a systemd
-service. You can also run the server manually as shown below.
+Use `./setup.sh` to configure local or SMB media storage and install systemd
+services. The script also installs a minimal X server and Chromium to show the
+fullscreen display. You can run the server manually as shown below.
 
 ### 3. Run the server
 ```bash
@@ -28,6 +30,9 @@ uvicorn main:app --host 0.0.0.0 --port 8000
 
 ### 4. Access the web UI
 Open your browser and go to `http://<device-ip>:8000/static/`
+
+The device itself runs a browser in kiosk mode showing `/static/display.html`.
+Selecting a file in the web UI will immediately update the fullscreen display.
 
 ### Uploading media
 Use the form on the index page to upload files. They are stored in the media

--- a/main.py
+++ b/main.py
@@ -29,6 +29,7 @@ def save_config(conf):
 config = load_config()
 config.setdefault('media_root', 'media')
 config.setdefault('selected_folders', [])
+config.setdefault('current_media', '')
 os.makedirs(config['media_root'], exist_ok=True)
 
 # expose helpers for modules
@@ -46,8 +47,9 @@ for module_name in os.listdir(MODULES_PATH):
             mod.init_module(app, config)
         loaded_modules[module_name] = mod
 
-# Mount static files for frontend
+# Mount static files for frontend and media files
 app.mount('/static', StaticFiles(directory='static'), name='static')
+app.mount('/media', StaticFiles(directory=config['media_root']), name='media')
 
 @app.get('/')
 def root():

--- a/modules/display/__init__.py
+++ b/modules/display/__init__.py
@@ -1,0 +1,36 @@
+import os
+from fastapi import APIRouter, HTTPException
+
+
+def init_module(app, config):
+    router = APIRouter()
+    media_root = config.get('media_root', 'media')
+
+    config.setdefault('current_media', '')
+
+    @router.get('/api/media/list')
+    def list_media():
+        files = []
+        for root, _, filenames in os.walk(media_root):
+            for name in filenames:
+                rel = os.path.relpath(os.path.join(root, name), media_root)
+                files.append(rel)
+        return {'files': files}
+
+    @router.post('/api/display/{path:path}')
+    def set_display(path: str):
+        normalized = os.path.normpath(path)
+        full = os.path.join(media_root, normalized)
+        if not os.path.isfile(full):
+            raise HTTPException(status_code=404, detail='File not found')
+        if os.path.commonpath([os.path.abspath(full), os.path.abspath(media_root)]) != os.path.abspath(media_root):
+            raise HTTPException(status_code=400, detail='Invalid path')
+        config['current_media'] = normalized
+        app.state.save_config(config)
+        return {'status': 'ok'}
+
+    @router.get('/api/display')
+    def get_display():
+        return {'file': config.get('current_media', '')}
+
+    app.include_router(router)

--- a/static/display.html
+++ b/static/display.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Display</title>
+    <style>
+        html, body {
+            margin: 0;
+            background: black;
+            height: 100%;
+            overflow: hidden;
+        }
+        #container {
+            width: 100vw;
+            height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+        img, video, iframe {
+            width: 100vw;
+            height: 100vh;
+            object-fit: contain;
+            background: black;
+        }
+    </style>
+</head>
+<body>
+<div id="container"></div>
+<script>
+let current = '';
+function showMedia(file){
+    const container = document.getElementById('container');
+    container.innerHTML = '';
+    if(!file) return;
+    const ext = file.split('.').pop().toLowerCase();
+    if(['mp4','webm','ogg'].includes(ext)){
+        const vid=document.createElement('video');
+        vid.src='/media/'+file;
+        vid.autoplay=true;
+        vid.loop=true;
+        vid.controls=false;
+        container.appendChild(vid);
+    } else if(['html','htm'].includes(ext)){
+        const frame=document.createElement('iframe');
+        frame.src='/media/'+file;
+        container.appendChild(frame);
+    } else {
+        const img=document.createElement('img');
+        img.src='/media/'+file;
+        container.appendChild(img);
+    }
+}
+async function poll(){
+    const res = await fetch('/api/display');
+    const data = await res.json();
+    if(data.file !== current){
+        current = data.file;
+        showMedia(current);
+    }
+}
+setInterval(poll, 2000);
+poll();
+</script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -12,6 +12,8 @@
     </form>
     <p><a href="/static/smb.html">SMB Browser</a></p>
     <div id="result"></div>
+    <h2>Files</h2>
+    <ul id="files"></ul>
     <script>
     document.getElementById('uploadForm').onsubmit = async (e) => {
         e.preventDefault();
@@ -21,7 +23,27 @@
         const res = await fetch('/api/upload', {method: 'POST', body: fd});
         const data = await res.json();
         document.getElementById('result').textContent = data.status ? 'Uploaded ' + data.filename : 'Error';
+        loadFiles();
     };
+
+    async function loadFiles() {
+        const res = await fetch('/api/media/list');
+        const data = await res.json();
+        const list = document.getElementById('files');
+        list.innerHTML = '';
+        if (data.files) {
+            data.files.forEach(f => {
+                const li = document.createElement('li');
+                const btn = document.createElement('button');
+                btn.textContent = 'Show';
+                btn.onclick = () => fetch('/api/display/' + encodeURIComponent(f), {method: 'POST'});
+                li.textContent = f + ' ';
+                li.appendChild(btn);
+                list.appendChild(li);
+            });
+        }
+    }
+    window.onload = loadFiles;
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support tracking currently selected media
- serve media files and show fullscreen display
- add display module with API for listing/selecting media
- create display.html and extend web UI for choosing files
- update setup script to install browser and create kiosk service
- document fullscreen display in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687c1245d760832ba4084dbfcfaed395