### PR TITLE
Fix dependency issues and update setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+python-multipart

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,9 @@ set -e
 echo "=== EchoView Setup ==="
 echo "Installing display dependencies..."
 sudo apt-get update
-sudo apt-get install -y chromium-browser xserver-xorg xinit
+sudo apt-get install -y chromium-browser xserver-xorg xinit python3-pip
+echo "Installing Python dependencies..."
+pip3 install -r requirements.txt
 MEDIA_ROOT="$(pwd)/media"
 read -p "Use SMB share? (y/n) " use_smb
 if [ "$use_smb" = "y" ]; then


### PR DESCRIPTION
## Summary
- add python-multipart requirement for file uploads
- install python dependencies during setup

## Testing
- `pip install -r requirements.txt`
- `pip install python-multipart`
- `uvicorn main:app --port 8000 --host 127.0.0.1 &`
- `curl http://127.0.0.1:8000/`
- `curl -X POST -F 'file=@test.txt' http://127.0.0.1:8000/api/upload`
- `curl http://127.0.0.1:8000/api/media/list`
- `curl -X POST http://127.0.0.1:8000/api/display/test.txt`
- `curl http://127.0.0.1:8000/api/display`
- `curl http://127.0.0.1:8000/api/smb/folders`


------
https://chatgpt.com/codex/tasks/task_e_687c15ab225c832bb55ddcf9a9e2a1fa