### PR TITLE
Implement Spotify integration with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ A modular, web-controlled media display application for Linux devices (e.g., Ras
 - Persistent settings
 - Updatable from GitHub
 - SMB share integration
-- Spotify integration (planned)
+- Spotify integration with fallback display
 - Fullscreen media display controllable from the web UI
+- Remote website support in the display
 
 ## Getting Started
 

--- a/modules/display/__init__.py
+++ b/modules/display/__init__.py
@@ -19,6 +19,11 @@ def init_module(app, config):
 
     @router.post('/api/display/{path:path}')
     def set_display(path: str):
+        if path.startswith('http://') or path.startswith('https://'):
+            config['current_media'] = path
+            app.state.save_config(config)
+            return {'status': 'ok'}
+
         normalized = os.path.normpath(path)
         full = os.path.join(media_root, normalized)
         if not os.path.isfile(full):

--- a/modules/spotify/__init__.py
+++ b/modules/spotify/__init__.py
@@ -1,0 +1,103 @@
+import os
+import threading
+import time
+from fastapi import APIRouter, Request, Body
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+
+
+def init_module(app, config):
+    router = APIRouter()
+    spotify_conf = config.setdefault('spotify', {})
+    spotify_conf.setdefault('tokens', {})
+    spotify_conf.setdefault('fallback', '')
+
+    status = {
+        'playing': False,
+        'artist': '',
+        'title': '',
+        'album_image': '',
+        'progress_ms': 0,
+        'duration_ms': 0,
+    }
+
+    def save_conf():
+        app.state.save_config(config)
+
+    def get_auth():
+        return SpotifyOAuth(
+            scope='user-read-playback-state',
+            client_id=os.getenv('SPOTIPY_CLIENT_ID'),
+            client_secret=os.getenv('SPOTIPY_CLIENT_SECRET'),
+            redirect_uri=os.getenv('SPOTIPY_REDIRECT_URI') or 'http://localhost:8000/api/spotify/callback'
+        )
+
+    def get_spotify():
+        tokens = spotify_conf.get('tokens')
+        if not tokens:
+            return None
+        auth = get_auth()
+        auth.cache_handler.save_token_to_cache(tokens)
+        token_info = auth.cache_handler.get_cached_token()
+        if not token_info:
+            return None
+        if auth.is_token_expired(token_info):
+            token_info = auth.refresh_access_token(token_info['refresh_token'])
+            spotify_conf['tokens'] = token_info
+            save_conf()
+        return spotipy.Spotify(auth=token_info['access_token'])
+
+    def poll():
+        while True:
+            sp = get_spotify()
+            if sp:
+                try:
+                    current = sp.current_playback()
+                    if current and current.get('item'):
+                        item = current['item']
+                        status.update({
+                            'playing': current['is_playing'],
+                            'artist': ', '.join(a['name'] for a in item['artists']),
+                            'title': item['name'],
+                            'album_image': item['album']['images'][0]['url'] if item['album']['images'] else '',
+                            'progress_ms': current['progress_ms'],
+                            'duration_ms': item['duration_ms'],
+                        })
+                    else:
+                        status['playing'] = False
+                except Exception as e:
+                    status['playing'] = False
+                    status['error'] = str(e)
+            else:
+                status['playing'] = False
+            time.sleep(5)
+
+    threading.Thread(target=poll, daemon=True).start()
+
+    @router.get('/api/spotify/auth_url')
+    def auth_url():
+        url = get_auth().get_authorize_url()
+        return {'url': url}
+
+    @router.get('/api/spotify/callback')
+    def callback(request: Request):
+        code = request.query_params.get('code')
+        if not code:
+            return {'error': 'missing code'}
+        auth = get_auth()
+        token_info = auth.get_access_token(code, as_dict=True)
+        spotify_conf['tokens'] = token_info
+        save_conf()
+        return {'status': 'ok'}
+
+    @router.get('/api/spotify/status')
+    def get_status():
+        return {'status': status, 'fallback': spotify_conf.get('fallback', '')}
+
+    @router.post('/api/spotify/fallback')
+    def set_fallback(data: dict = Body(...)):
+        spotify_conf['fallback'] = data.get('file', '')
+        save_conf()
+        return {'status': 'ok'}
+
+    app.include_router(router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 python-multipart
+spotipy

--- a/static/display.html
+++ b/static/display.html
@@ -27,6 +27,13 @@
 </head>
 <body>
 <div id="container"></div>
+<div id="spotify" style="position:absolute;bottom:0;left:0;right:0;text-align:center;color:white;background:rgba(0,0,0,0.5);display:none;">
+    <img id="album" src="" style="height:100px"><br>
+    <span id="artist"></span> - <span id="title"></span>
+    <div style="width:100%;background:#333;height:5px;">
+        <div id="progress" style="background:#1db954;height:5px;width:0%"></div>
+    </div>
+</div>
 <script>
 let current = '';
 function showMedia(file){
@@ -36,27 +43,49 @@ function showMedia(file){
     const ext = file.split('.').pop().toLowerCase();
     if(['mp4','webm','ogg'].includes(ext)){
         const vid=document.createElement('video');
-        vid.src='/media/'+file;
+        vid.src=file.startsWith('http')?file:'/media/'+file;
         vid.autoplay=true;
         vid.loop=true;
         vid.controls=false;
         container.appendChild(vid);
     } else if(['html','htm'].includes(ext)){
         const frame=document.createElement('iframe');
-        frame.src='/media/'+file;
+        frame.src=file.startsWith('http')?file:'/media/'+file;
         container.appendChild(frame);
     } else {
         const img=document.createElement('img');
-        img.src='/media/'+file;
+        img.src=file.startsWith('http')?file:'/media/'+file;
         container.appendChild(img);
     }
 }
+function showSpotify(stat){
+    const s=document.getElementById('spotify');
+    s.style.display='block';
+    document.getElementById('album').src=stat.album_image;
+    document.getElementById('artist').textContent=stat.artist;
+    document.getElementById('title').textContent=stat.title;
+    if(stat.duration_ms>0){
+        document.getElementById('progress').style.width=(stat.progress_ms/stat.duration_ms*100)+'%';
+    }
+}
 async function poll(){
-    const res = await fetch('/api/display');
-    const data = await res.json();
-    if(data.file !== current){
-        current = data.file;
-        showMedia(current);
+    const [dispRes, spotRes] = await Promise.all([
+        fetch('/api/display'),
+        fetch('/api/spotify/status')
+    ]);
+    const data = await dispRes.json();
+    const sp = await spotRes.json();
+    const spot = sp.status;
+    if(spot.playing){
+        if(current !== 'spotify'){ current='spotify'; }
+        showSpotify(spot);
+    } else {
+        document.getElementById('spotify').style.display='none';
+        const target = data.file || sp.fallback;
+        if(target !== current){
+            current = target;
+            showMedia(target);
+        }
     }
 }
 setInterval(poll, 2000);

--- a/static/index.html
+++ b/static/index.html
@@ -11,6 +11,8 @@
         <button type="submit">Upload</button>
     </form>
     <p><a href="/static/smb.html">SMB Browser</a></p>
+    <p><button id="spotifyLogin">Connect Spotify</button></p>
+    <p>Fallback when Spotify idle: <select id="fallbackSelect"></select> <button id="setFallback">Set</button></p>
     <div id="result"></div>
     <h2>Files</h2>
     <ul id="files"></ul>
@@ -40,10 +42,34 @@
                 li.textContent = f + ' ';
                 li.appendChild(btn);
                 list.appendChild(li);
+                const opt = document.createElement('option');
+                opt.value = f;
+                opt.textContent = f;
+                document.getElementById('fallbackSelect').appendChild(opt);
             });
         }
     }
-    window.onload = loadFiles;
+    async function loadSpotify(){
+        const res = await fetch('/api/spotify/status');
+        const data = await res.json();
+        if(data.fallback){
+            document.getElementById('fallbackSelect').value = data.fallback;
+        }
+    }
+    document.getElementById('spotifyLogin').onclick = async () => {
+        const res = await fetch('/api/spotify/auth_url');
+        const data = await res.json();
+        if(data.url) window.location = data.url;
+    };
+    document.getElementById('setFallback').onclick = async () => {
+        const file = document.getElementById('fallbackSelect').value;
+        await fetch('/api/spotify/fallback', {
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({file})
+        });
+    };
+    window.onload = () => {loadFiles();loadSpotify();};
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add new Spotify module for OAuth and playback status
- allow remote URLs in display module
- overlay Spotify info on display
- update index page for Spotify controls
- document new features

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_687c1724c35c832bb032ec5f491d575f