### PR TITLE
Add update button and media preload improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A modular, web-controlled media display application for Linux devices (e.g., Ras
 - Spotify integration with fallback display
 - Fullscreen media display controllable from the web UI
 - Remote website support in the display
+- Media viewer preloads upcoming items and shows a blurred background of the
+  current frame for seamless transitions
 
 ## Getting Started
 
@@ -48,6 +50,8 @@ exposed at `/update` which will fetch the latest commit from
 `https://github.com/tpersp/EchoView.git` and reset the local copy. Any JSON
 configuration files are backed up and restored so your settings remain intact.
 Local changes to the code are discarded.
+The main web page includes an **Update from GitHub** button that triggers this
+endpoint so you can easily stay on the latest release.
 
 ## Persistent Settings
 Settings are stored in `config/settings.json` and survive reboots/service

--- a/static/display.html
+++ b/static/display.html
@@ -10,6 +10,18 @@
             height: 100%;
             overflow: hidden;
         }
+        #background {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-size: cover;
+            background-position: center;
+            filter: blur(20px);
+            transform: scale(1.1);
+            z-index: -1;
+        }
         #container {
             width: 100vw;
             height: 100vh;
@@ -26,6 +38,7 @@
     </style>
 </head>
 <body>
+<div id="background"></div>
 <div id="container"></div>
 <div id="spotify" style="position:absolute;bottom:0;left:0;right:0;text-align:center;color:white;background:rgba(0,0,0,0.5);display:none;">
     <img id="album" src="" style="height:100px"><br>
@@ -36,26 +49,34 @@
 </div>
 <script>
 let current = '';
+let queue = [];
+let qIndex = 0;
+let preloaded = {};
 function showMedia(file){
     const container = document.getElementById('container');
+    const bg = document.getElementById('background');
     container.innerHTML = '';
-    if(!file) return;
+    if(!file){ bg.style.backgroundImage=''; return; }
+    const url = file.startsWith('http')?file:'/media/'+file;
     const ext = file.split('.').pop().toLowerCase();
     if(['mp4','webm','ogg'].includes(ext)){
         const vid=document.createElement('video');
-        vid.src=file.startsWith('http')?file:'/media/'+file;
+        vid.src=url;
         vid.autoplay=true;
         vid.loop=true;
         vid.controls=false;
         container.appendChild(vid);
+        bg.style.backgroundImage='url("'+url+'");'
     } else if(['html','htm'].includes(ext)){
         const frame=document.createElement('iframe');
-        frame.src=file.startsWith('http')?file:'/media/'+file;
+        frame.src=url;
         container.appendChild(frame);
+        bg.style.backgroundImage='';
     } else {
         const img=document.createElement('img');
-        img.src=file.startsWith('http')?file:'/media/'+file;
+        img.src=url;
         container.appendChild(img);
+        bg.style.backgroundImage='url("'+url+'");'
     }
 }
 function showSpotify(stat){
@@ -68,6 +89,46 @@ function showSpotify(stat){
         document.getElementById('progress').style.width=(stat.progress_ms/stat.duration_ms*100)+'%';
     }
 }
+async function loadQueue(){
+    const res = await fetch('/api/smb/mix');
+    const data = await res.json();
+    queue = data.files || [];
+    qIndex = 0;
+    updatePreload();
+}
+
+function updatePreload(){
+    const needed = [];
+    for(let i=0;i<3 && i<queue.length;i++){
+        const idx = (qIndex+i)%queue.length;
+        needed.push(queue[idx]);
+        const f = queue[idx];
+        if(!preloaded[f]){
+            const ext = f.split('.').pop().toLowerCase();
+            const url = '/media/'+f;
+            if(['mp4','webm','ogg'].includes(ext)){
+                const v=document.createElement('video');
+                v.src=url;
+            }else{
+                const img=new Image();
+                img.src=url;
+            }
+            preloaded[f]=true;
+        }
+    }
+    for(const f in preloaded){
+        if(!needed.includes(f)) delete preloaded[f];
+    }
+}
+
+function nextFromQueue(){
+    if(queue.length===0) return null;
+    const f = queue[qIndex];
+    qIndex = (qIndex+1)%queue.length;
+    updatePreload();
+    return f;
+}
+
 async function poll(){
     const [dispRes, spotRes] = await Promise.all([
         fetch('/api/display'),
@@ -81,14 +142,18 @@ async function poll(){
         showSpotify(spot);
     } else {
         document.getElementById('spotify').style.display='none';
-        const target = data.file || sp.fallback;
-        if(target !== current){
+        let target = data.file || sp.fallback;
+        if(!target){
+            if(queue.length===0) await loadQueue();
+            target = nextFromQueue();
+        }
+        if(target && target !== current){
             current = target;
             showMedia(target);
         }
     }
 }
-setInterval(poll, 2000);
+setInterval(poll, 5000);
 poll();
 </script>
 </body>

--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,7 @@
     <p><a href="/static/smb.html">SMB Browser</a></p>
     <p><button id="spotifyLogin">Connect Spotify</button></p>
     <p>Fallback when Spotify idle: <select id="fallbackSelect"></select> <button id="setFallback">Set</button></p>
+    <p><button id="updateBtn">Update from GitHub</button></p>
     <div id="result"></div>
     <h2>Files</h2>
     <ul id="files"></ul>
@@ -32,7 +33,9 @@
         const res = await fetch('/api/media/list');
         const data = await res.json();
         const list = document.getElementById('files');
+        const fallback = document.getElementById('fallbackSelect');
         list.innerHTML = '';
+        fallback.innerHTML = '';
         if (data.files) {
             data.files.forEach(f => {
                 const li = document.createElement('li');
@@ -45,7 +48,7 @@
                 const opt = document.createElement('option');
                 opt.value = f;
                 opt.textContent = f;
-                document.getElementById('fallbackSelect').appendChild(opt);
+                fallback.appendChild(opt);
             });
         }
     }
@@ -68,6 +71,11 @@
             headers:{'Content-Type':'application/json'},
             body: JSON.stringify({file})
         });
+    };
+    document.getElementById('updateBtn').onclick = async () => {
+        const res = await fetch('/update', {method:'POST'});
+        const data = await res.json();
+        alert(data.status || 'Update failed');
     };
     window.onload = () => {loadFiles();loadSpotify();};
     </script>


### PR DESCRIPTION
## Summary
- prevent duplicate fallback options on each load
- expose update-from-GitHub button in the web UI
- add blurred background and preload upcoming media files
- document new update button and preload behaviour

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687c1b1694d4832b8b593c33634259c0