### PR TITLE
Fix web UI access

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, responses
 from fastapi.staticfiles import StaticFiles
 import importlib
 import os
@@ -48,12 +48,13 @@ for module_name in os.listdir(MODULES_PATH):
         loaded_modules[module_name] = mod
 
 # Mount static files for frontend and media files
-app.mount('/static', StaticFiles(directory='static'), name='static')
+app.mount('/static', StaticFiles(directory='static', html=True), name='static')
 app.mount('/media', StaticFiles(directory=config['media_root']), name='media')
 
 @app.get('/')
 def root():
-    return {'message': 'EchoView server running'}
+    """Redirect the browser to the main web interface."""
+    return responses.RedirectResponse(url='/static/')
 
 
 @app.post('/update')


### PR DESCRIPTION
## Summary
- redirect root URL to the web UI
- allow `/static/` to serve `index.html`

## Testing
- `python3 -m py_compile main.py modules/*/__init__.py updater/update.py`
- `curl -s -o /tmp/resp -D - http://127.0.0.1:8000/`
- `curl -L -s http://127.0.0.1:8000/ | head`


------
https://chatgpt.com/codex/tasks/task_e_687c26be5624832ba0b6224856463f2a