### PR TITLE
Add --no-sandbox to kiosk service

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -63,7 +63,7 @@ After=echoview.service
 [Service]
 Type=simple
 Environment=DISPLAY=:0
-ExecStart=/usr/bin/xinit /usr/bin/chromium-browser --noerrdialogs --disable-infobars --kiosk http://localhost:8000/static/display.html -- :0
+ExecStart=/usr/bin/xinit /usr/bin/chromium-browser --noerrdialogs --disable-infobars --kiosk http://localhost:8000/static/display.html --no-sandbox -- :0
 Restart=always
 
 [Install]


### PR DESCRIPTION
## Summary
- allow chromium to run as root in kiosk service

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c299aade0832bbacf7fd7154935f2