### PR TITLE
Improve UI with dark theme and navigation

### DIFF
--- a/static/display.html
+++ b/static/display.html
@@ -3,48 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <title>Display</title>
-    <style>
-        html, body {
-            margin: 0;
-            background: black;
-            height: 100%;
-            overflow: hidden;
-        }
-        #background {
-            position: fixed;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background-size: cover;
-            background-position: center;
-            filter: blur(20px);
-            transform: scale(1.1);
-            z-index: -1;
-        }
-        #container {
-            width: 100vw;
-            height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-        img, video, iframe {
-            width: 100vw;
-            height: 100vh;
-            object-fit: contain;
-            background: black;
-        }
-    </style>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
+<nav>
+    <a href="/static/">Home</a>
+    <a href="/static/smb.html">SMB Browser</a>
+    <a href="/static/display.html">Display</a>
+</nav>
 <div id="background"></div>
 <div id="container"></div>
-<div id="spotify" style="position:absolute;bottom:0;left:0;right:0;text-align:center;color:white;background:rgba(0,0,0,0.5);display:none;">
-    <img id="album" src="" style="height:100px"><br>
+<div id="spotify">
+    <img id="album" src=""><br>
     <span id="artist"></span> - <span id="title"></span>
-    <div style="width:100%;background:#333;height:5px;">
-        <div id="progress" style="background:#1db954;height:5px;width:0%"></div>
+    <div class="progress-container">
+        <div id="progress"></div>
     </div>
 </div>
 <script>

--- a/static/index.html
+++ b/static/index.html
@@ -3,14 +3,19 @@
 <head>
     <meta charset="UTF-8">
     <title>EchoView</title>
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
+    <nav>
+        <a href="/static/">Home</a>
+        <a href="/static/smb.html">SMB Browser</a>
+        <a href="/static/display.html">Display</a>
+    </nav>
     <h1>EchoView Web Control</h1>
     <form id="uploadForm">
         <input type="file" name="file" id="fileInput" />
         <button type="submit">Upload</button>
     </form>
-    <p><a href="/static/smb.html">SMB Browser</a></p>
     <p><button id="spotifyLogin">Connect Spotify</button></p>
     <p>Fallback when Spotify idle: <select id="fallbackSelect"></select> <button id="setFallback">Set</button></p>
     <p><button id="updateBtn">Update from GitHub</button></p>

--- a/static/smb.html
+++ b/static/smb.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>SMB Browser</title>
+    <link rel="stylesheet" href="/static/style.css">
     <script>
     async function loadFolders() {
         const res = await fetch('/api/smb/folders');
@@ -47,6 +48,11 @@
     </script>
 </head>
 <body>
+    <nav>
+        <a href="/static/">Home</a>
+        <a href="/static/smb.html">SMB Browser</a>
+        <a href="/static/display.html">Display</a>
+    </nav>
     <h1>SMB Folder Browser</h1>
     <ul id="folders"></ul>
     <button onclick="selectFolders()">Select Folders</button>

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,87 @@
+:root {
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    --accent-color: #1db954;
+    --nav-bg: #1f1f1f;
+    --nav-link-color: #e0e0e0;
+    --nav-link-hover: #1db954;
+}
+body {
+    background: var(--bg-color);
+    color: var(--text-color);
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+nav {
+    background: var(--nav-bg);
+    padding: 10px;
+}
+nav a {
+    color: var(--nav-link-color);
+    text-decoration: none;
+    margin-right: 15px;
+}
+nav a:hover {
+    color: var(--nav-link-hover);
+}
+button, input, select {
+    background: #333;
+    color: var(--text-color);
+    border: 1px solid #555;
+    padding: 5px 10px;
+    border-radius: 3px;
+}
+ul {
+    list-style: none;
+    padding: 0;
+}
+#container {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+img, video, iframe {
+    width: 100vw;
+    height: 100vh;
+    object-fit: contain;
+    background: black;
+}
+#background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-size: cover;
+    background-position: center;
+    filter: blur(20px);
+    transform: scale(1.1);
+    z-index: -1;
+}
+#spotify {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    color: white;
+    background: rgba(0,0,0,0.5);
+    display: none;
+}
+#spotify img {
+    height: 100px;
+}
+.progress-container {
+    width: 100%;
+    background: #333;
+    height: 5px;
+}
+#progress {
+    background: var(--accent-color);
+    height: 5px;
+    width: 0%;
+}
+


### PR DESCRIPTION
## Summary
- add a reusable dark themed stylesheet
- incorporate navigation menu into pages
- apply consistent styling across pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c2b4ba5b8832bb60fdd027718d35b