### PR TITLE
Implement lightweight viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ pip install -r requirements.txt
 
 ### 2. Run setup (optional)
 Use `./setup.sh` to configure local or SMB media storage and install systemd
-services. The script also installs a minimal X server and Chromium to show the
-fullscreen display. You can run the server manually as shown below.
+services. The script installs a minimal X server and a small Python based
+viewer that displays the fullscreen slideshow without launching a full browser.
+You can run the server manually as shown below.
 
 ### 3. Run the server
 ```bash
@@ -34,8 +35,16 @@ uvicorn main:app --host 0.0.0.0 --port 8000
 ### 4. Access the web UI
 Open your browser and go to `http://<device-ip>:8000/static/`
 
-The device itself runs a browser in kiosk mode showing `/static/display.html`.
-Selecting a file in the web UI will immediately update the fullscreen display.
+The device itself runs a lightweight viewer that loads `/static/display.html` in
+fullscreen. Selecting a file in the web UI will immediately update the
+displayed content.
+
+### 5. Run the viewer manually
+If you are not using the systemd service from `setup.sh`, you can start the
+fullscreen viewer yourself:
+```bash
+python viewer.py
+```
 
 ### Uploading media
 Use the form on the index page to upload files. They are stored in the media

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 python-multipart
 spotipy
+pywebview

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ set -e
 echo "=== EchoView Setup ==="
 echo "Installing display dependencies..."
 sudo apt-get update
-sudo apt-get install -y chromium-browser xserver-xorg xinit python3-pip
+sudo apt-get install -y xserver-xorg xinit python3-pip
 echo "Installing Python dependencies..."
 pip3 install --break-system-packages -r requirements.txt
 MEDIA_ROOT="$(pwd)/media"
@@ -63,7 +63,7 @@ After=echoview.service
 [Service]
 Type=simple
 Environment=DISPLAY=:0
-ExecStart=/usr/bin/xinit /usr/bin/chromium-browser --noerrdialogs --disable-infobars --kiosk http://localhost:8000/static/display.html --no-sandbox -- :0
+ExecStart=/usr/bin/xinit $(which python3) $(pwd)/viewer.py -- :0
 Restart=always
 
 [Install]

--- a/viewer.py
+++ b/viewer.py
@@ -1,0 +1,5 @@
+import webview
+
+if __name__ == '__main__':
+    webview.create_window('EchoView Display', 'http://localhost:8000/static/display.html', fullscreen=True)
+    webview.start()


### PR DESCRIPTION
## Summary
- remove Chromium dependency and add a small python viewer
- update setup script to run the viewer instead of Chromium
- document viewer usage in README
- add `pywebview` dependency

## Testing
- `python -m py_compile main.py modules/*/__init__.py viewer.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687c300f064c832ba51ce705c4c74132