### PR TITLE
Configurable Spotify cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Browse to `http://<PI-IP>:8080` to access the interface. You’ll see:
 
 In `Configure Spotify`, provide your **Client ID**, **Client Secret**, and **Redirect URI** from the Spotify Developer Dashboard. Then click **Authorize Spotify** to store the OAuth token. You can set one or more displays to `spotify` mode.
 
+The OAuth token is cached at the location specified by the `SPOTIFY_CACHE_PATH`
+environment variable (default `VIEWER_HOME/.spotify_cache`). You can override
+this path by adding `SPOTIFY_CACHE_PATH` to your `.env` file.
+
 ### Media Upload
 
 Use the **Upload Media** page to add images/GIFs. You can place them in existing subfolders or create a new one. If you have a CIFS share, it will appear under your `IMAGE_DIR`.
@@ -134,7 +138,7 @@ sudo journalctl -u controller.service
 
 - **No images?** Ensure images exist in the `IMAGE_DIR` (or subfolders). By default, check `/mnt/EchoViews` or wherever you mounted.
 - **Wrong screen**? Confirm you have multiple monitors recognized by X. EchoView uses PySide6’s screen geometry, so make sure your environment is not on Wayland.
-- **Spotify issues**? Check `.spotify_cache` for the saved token. Re-authorize if needed.
+- **Spotify issues**? Check the file specified by `SPOTIFY_CACHE_PATH` for the saved token. Re-authorize if needed.
 - **Overlay not transparent?** You need a compositor (like **picom**) running for real transparency.
 - **Check logs**: Look at `echoview.log` (in your `VIEWER_HOME`) or `journalctl -u echoview.service`.
 

--- a/echoview/config.py
+++ b/echoview/config.py
@@ -36,6 +36,14 @@ CONFIG_PATH = os.path.join(VIEWER_HOME, "viewerconfig.json")
 LOG_PATH    = os.path.join(VIEWER_HOME, "viewer.log")
 WEB_BG      = os.path.join(VIEWER_HOME, "web_bg.jpg")
 
+# Location for SpotifyOAuth token cache. Can be overridden with environment
+# variable SPOTIFY_CACHE_PATH. Defaults to a file named '.spotify_cache' in
+# VIEWER_HOME.
+SPOTIFY_CACHE_PATH = os.environ.get(
+    "SPOTIFY_CACHE_PATH",
+    os.path.join(VIEWER_HOME, ".spotify_cache"),
+)
+
 # ------------------------------------------------------------
 # Git Update Branch
 # ------------------------------------------------------------

--- a/echoview/viewer.py
+++ b/echoview/viewer.py
@@ -26,7 +26,7 @@ from PySide6.QtWidgets import (
 )
 
 from spotipy.oauth2 import SpotifyOAuth
-from config import APP_VERSION, IMAGE_DIR, LOG_PATH, VIEWER_HOME
+from config import APP_VERSION, IMAGE_DIR, LOG_PATH, VIEWER_HOME, SPOTIFY_CACHE_PATH
 from utils import load_config, save_config, log_message
 
 
@@ -838,9 +838,13 @@ class DisplayWindow(QMainWindow):
             if not (cid and csec and ruri):
                 self.spotify_info = None
                 return None
-            auth = SpotifyOAuth(client_id=cid, client_secret=csec,
-                                redirect_uri=ruri, scope=scope,
-                                cache_path=".spotify_cache")
+            auth = SpotifyOAuth(
+                client_id=cid,
+                client_secret=csec,
+                redirect_uri=ruri,
+                scope=scope,
+                cache_path=SPOTIFY_CACHE_PATH,
+            )
             token_info = auth.get_cached_token()
             if not token_info:
                 self.spotify_info = None

--- a/echoview/web/routes.py
+++ b/echoview/web/routes.py
@@ -8,7 +8,15 @@ from flask import (
     Blueprint, request, redirect, url_for, render_template,
     send_from_directory, send_file, jsonify
 )
-from config import APP_VERSION, WEB_BG, IMAGE_DIR, LOG_PATH, UPDATE_BRANCH, VIEWER_HOME
+from config import (
+    APP_VERSION,
+    WEB_BG,
+    IMAGE_DIR,
+    LOG_PATH,
+    UPDATE_BRANCH,
+    VIEWER_HOME,
+    SPOTIFY_CACHE_PATH,
+)
 from utils import (
     load_config, save_config, init_config, log_message,
     get_system_stats, get_subfolders, count_files_in_folder,
@@ -367,7 +375,7 @@ def spotify_auth():
         client_secret=csec,
         redirect_uri=ruri,
         scope=scope,
-        cache_path=".spotify_cache"
+        cache_path=SPOTIFY_CACHE_PATH,
     )
     auth_url = sp_oauth.get_authorize_url()
     return redirect(auth_url)
@@ -386,7 +394,7 @@ def callback():
         client_secret=csec,
         redirect_uri=ruri,
         scope=scope,
-        cache_path=".spotify_cache"
+        cache_path=SPOTIFY_CACHE_PATH,
     )
     code = request.args.get("code")
     if not code:
@@ -600,9 +608,12 @@ def index():
     sub_info_line = ""
 
     sp_cfg = cfg.get("spotify", {})
-    if sp_cfg.get("client_id") and sp_cfg.get("client_secret") and sp_cfg.get("redirect_uri"):
-        spotify_cache_path = os.path.join(VIEWER_HOME, ".spotify_cache")
-        if os.path.exists(spotify_cache_path):
+    if (
+        sp_cfg.get("client_id")
+        and sp_cfg.get("client_secret")
+        and sp_cfg.get("redirect_uri")
+    ):
+        if os.path.exists(SPOTIFY_CACHE_PATH):
             spotify_status = "✅"
         else:
             spotify_status = "⚠️"

--- a/echoview/web/templates/configure_spotify.html
+++ b/echoview/web/templates/configure_spotify.html
@@ -35,8 +35,9 @@
   <div class="collapsible-content">
     <p>
       Click <strong>Authorize Spotify</strong> to begin the OAuth flow.
-      Once authorized, your token is cached in <code>.spotify_cache</code>,
-      and EchoView can fetch your currently playing track’s album art.
+      Once authorized, your token is cached at the path in
+      <code>SPOTIFY_CACHE_PATH</code>, and EchoView can fetch your currently
+      playing track’s album art.
     </p>
   </div>
 


### PR DESCRIPTION
## Summary
- add `SPOTIFY_CACHE_PATH` to config
- use `SPOTIFY_CACHE_PATH` everywhere SpotifyOAuth is created
- update web status check for the cache file
- document cache path variable in README and Spotify template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea85f57cc832b981f50b906c70245