### PR TITLE
Fix service launch paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ EchoView/
 Two services are created:
 
 - **echoview.service**
-  - Runs `echoview/viewer.py` at boot so the slideshows start automatically on every connected screen.
+  - Runs `python3 -m echoview.viewer` at boot so the slideshows start automatically on every connected screen.
 - **controller.service**
-  - Runs `echoview/web/app.py`, the Flask server on port 8080.
+  - Runs `python3 -m echoview.web.app`, the Flask server on port 8080.
 
 You can check their status or logs:
 

--- a/echoview/utils.py
+++ b/echoview/utils.py
@@ -9,13 +9,13 @@ import random
 import psutil
 from datetime import datetime
 
-from config import (
+from echoview.config import (
     APP_VERSION,
     VIEWER_HOME,
     IMAGE_DIR,
     CONFIG_PATH,
     LOG_PATH,
-    WEB_BG
+    WEB_BG,
 )
 
 def init_config():

--- a/setup.sh
+++ b/setup.sh
@@ -409,13 +409,13 @@ Wants=lightdm.service
 [Service]
 User=$VIEWER_USER
 Group=$VIEWER_USER
-WorkingDirectory=$VIEWER_HOME/echoview
+WorkingDirectory=$VIEWER_HOME
 EnvironmentFile=$ENV_FILE
 Environment="DISPLAY=:0"
 Environment="XAUTHORITY=/home/$VIEWER_USER/.Xauthority"
 Environment="QT_QPA_PLATFORM_PLUGIN_PATH=/usr/local/lib/python3.11/dist-packages/PySide6/Qt/plugins/platforms"
 ExecStartPre=/bin/sleep 5
-ExecStart=/usr/bin/python3 $VIEWER_HOME/echoview/viewer.py
+ExecStart=/usr/bin/python3 -m echoview.viewer
 
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Summary
- change utils import to package path
- run slideshow via `-m echoview.viewer` in service setup
- update README documentation for systemd services

## Testing
- `python3 -m pip install -r dependencies.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815d303840832bb0717e6a16f72418