### PR TITLE
Enhance UI and feedback

### DIFF
--- a/echoview/web/templates/base.html
+++ b/echoview/web/templates/base.html
@@ -2,9 +2,11 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}EchoView{% endblock %}</title>
   <!-- Set tab icon to icon.png -->
   <link rel="icon" href="{{ url_for('static', filename='icon.png') }}">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="{{ theme }}-theme">
@@ -83,6 +85,7 @@
   {% block content %}{% endblock %}
 </main>
 
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="{{ url_for('static', filename='script.js') }}"></script>
 {% block extra_scripts %}{% endblock %}
 </body>

--- a/echoview/web/templates/configure_spotify.html
+++ b/echoview/web/templates/configure_spotify.html
@@ -4,6 +4,13 @@
 
 <div class="page-section" style="max-width:1200px;">
   <h2>Configure Spotify Integration</h2>
+  {% if not creds_set %}
+  <div class="flash-message">Missing credentials. Fill in the form below.</div>
+  {% elif not token_cached %}
+  <div class="flash-message">Credentials saved but token not authorized.</div>
+  {% else %}
+  <div class="flash-message">Spotify authorized.</div>
+  {% endif %}
 
   <!-- Collapsible Steps -->
   <div class="collapsible-header">1. Spotify Developer Dashboard</div>

--- a/echoview/web/templates/index.html
+++ b/echoview/web/templates/index.html
@@ -187,7 +187,7 @@
               {% endfor %}
             </div>
             {% else %}
-              <p>No images found or category is empty.</p>
+              <p>No images found or category is empty. <a href="{{ url_for('main.upload_media') }}">Upload some?</a></p>
             {% endif %}
           {% endif %}
           <br>
@@ -205,7 +205,7 @@
   <!-- Bottom status row as its own card -->
   <div class="card" style="margin-top:20px; text-align:center;">
     <strong>Status:</strong>
-    Spotify: {{ spotify_status }}
+    Spotify Status: {{ spotify_status }}
   </div>
 </div>
 

--- a/echoview/web/templates/overlay.html
+++ b/echoview/web/templates/overlay.html
@@ -73,5 +73,19 @@
       <button type="submit">Save All Overlay Settings</button>
     </div>
   </form>
+  <h3 style="margin-top:20px; text-align:center;">Overlay Layout Preview</h3>
+  <div class="overlay-preview-container">
+    <div id="overlayPreviewBox" class="overlay-preview-box" style="width:{{ preview_w }}px; height:{{ preview_h }}px;">
+      <div id="overlayDraggable" class="overlay-draggable-box" style="width:{{ preview_overlay.width }}px; height:{{ preview_overlay.height }}px; left:{{ offset_x }}px; top:{{ offset_y }}px;"></div>
+    </div>
+  </div>
+  <input type="hidden" name="offset_x" id="offset_x" value="{{ offset_x }}">
+  <input type="hidden" name="offset_y" id="offset_y" value="{{ offset_y }}">
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+  var scaleFactor = {{ '%.4f' % scale_factor }};
+</script>
 {% endblock %}

--- a/echoview/web/templates/upload_media.html
+++ b/echoview/web/templates/upload_media.html
@@ -24,4 +24,38 @@
   </form>
 </div>
 
+<div class="page-section" style="max-width:1200px; margin-top:20px;">
+  <h2>Manage Files</h2>
+  {% for folder, files in folder_files.items() %}
+  <div class="card" style="margin-bottom:10px;">
+    <h4>{{ folder }}</h4>
+    <form method="post" action="{{ url_for('main.rename_folder') }}" class="d-flex" style="gap:10px;">
+      <input type="hidden" name="folder" value="{{ folder }}">
+      <input type="text" name="new_name" placeholder="Rename folder">
+      <button type="submit">Rename</button>
+    </form>
+    <form method="post" action="{{ url_for('main.delete_folder') }}" style="margin-top:5px;">
+      <input type="hidden" name="folder" value="{{ folder }}">
+      <button type="submit">Delete Folder</button>
+    </form>
+    <ul>
+      {% for f in files %}
+      <li>
+        {{ f }}
+        <form method="post" action="{{ url_for('main.rename_image') }}" class="d-inline">
+          <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
+          <input type="text" name="new_name" placeholder="rename">
+          <button type="submit">Rename</button>
+        </form>
+        <form method="post" action="{{ url_for('main.delete_image') }}" class="d-inline">
+          <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
+          <button type="submit">Delete</button>
+        </form>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endfor %}
+</div>
+
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Bootstrap and viewport support
- improve Spotify status messages
- show link to upload images when folder empty
- add overlay layout preview with drag-and-drop
- provide media management actions for delete/rename
- display credential status on Spotify config page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a2c41c84832b9e64103dca22f576