### PR TITLE
Improve web UI readability and media manager

### DIFF
--- a/echoview/web/static/style.css
+++ b/echoview/web/static/style.css
@@ -206,12 +206,12 @@ table td button {
    ---------------------------------------------- */
 .dark-theme {
   --nav-bg: #1E1E1E;
-  --nav-fg: #EEE;
+  --nav-fg: #FFF;
   --nav-hover: rgba(255,255,255,0.1);
   --nav-active: #444;
   --nav-active-fg: #FFF;
 
-  --text-normal: #ECECEC;
+  --text-normal: #F5F5F5;
   --input-border: #555;
   --input-bg: #3A3A3A;
   --section-bg: rgba(255,255,255,0.06);
@@ -224,7 +224,7 @@ table td button {
   --collapsible-hover: rgba(255,255,255,0.15);
   --overlay-preview-bg: rgba(0,0,0,0.2);
   background: #121212;
-  color: #ECECEC;
+  color: var(--text-normal);
 
   /* Additional dropdown variables for dark theme */
   --dropdown-bg: #333;
@@ -306,3 +306,24 @@ table td button {
 .nav-item.dropdown .dropdown-content button:hover {
   background-color: var(--dropdown-hover-bg);
 }
+
+/* Media management grid layout */
+#file-manager .folder-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+#file-manager .file-item {
+  text-align: center;
+}
+
+#file-manager .file-thumb {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border: 2px solid var(--border-muted);
+  border-radius: 4px;
+}
+

--- a/echoview/web/templates/index.html
+++ b/echoview/web/templates/index.html
@@ -139,7 +139,7 @@
           <label>Multiple Folders (drag to reorder):</label><br>
           <input type="text" placeholder="Search..." id="{{ dname }}_search" style="width:90%;"><br>
           <div style="display:flex; gap:10px; margin-top:10px;">
-            <ul id="{{ dname }}_availList" style="flex:1; list-style:none; border:1px solid var(--border-muted); padding:5px; max-height:120px; overflow:auto;">
+            <ul id="{{ dname }}_availList" style="flex:1; list-style:none; border:1px solid var(--border-muted); padding:5px;">
               {% for sf in subfolders %}
                 {% if sf not in dcfg.mixed_folders %}
                   <li draggable="true" data-folder="{{ sf }}" style="margin:4px; border:1px solid #666; border-radius:4px; cursor:move; padding:4px;">
@@ -148,7 +148,7 @@
                 {% endif %}
               {% endfor %}
             </ul>
-            <ul id="{{ dname }}_selList" style="flex:1; list-style:none; border:1px solid var(--border-muted); padding:5px; max-height:120px; overflow:auto;">
+            <ul id="{{ dname }}_selList" style="flex:1; list-style:none; border:1px solid var(--border-muted); padding:5px;">
               {% for sf in dcfg.mixed_folders %}
                   <li draggable="true" data-folder="{{ sf }}" style="margin:4px; border:1px solid #666; border-radius:4px; cursor:move; padding:4px;">
                     {{ sf }} ({{ folder_counts[sf]|default(0) }})

--- a/echoview/web/templates/upload_media.html
+++ b/echoview/web/templates/upload_media.html
@@ -24,7 +24,7 @@
   </form>
 </div>
 
-<div class="page-section" style="max-width:1200px; margin-top:20px;">
+<div class="page-section" style="max-width:1200px; margin-top:20px;" id="file-manager">
   <h2>Manage Files</h2>
   {% for folder, files in folder_files.items() %}
   <div class="card" style="margin-bottom:10px;">
@@ -38,10 +38,11 @@
       <input type="hidden" name="folder" value="{{ folder }}">
       <button type="submit">Delete Folder</button>
     </form>
-    <ul>
+    <div class="folder-grid">
       {% for f in files %}
-      <li>
-        {{ f }}
+      <div class="file-item">
+        <img src="/images/{{ folder }}/{{ f }}" class="file-thumb">
+        <div class="filename" style="word-break:break-all;">{{ f }}</div>
         <form method="post" action="{{ url_for('main.rename_image') }}" class="d-inline">
           <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
           <input type="text" name="new_name" placeholder="rename">
@@ -51,9 +52,9 @@
           <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
           <button type="submit">Delete</button>
         </form>
-      </li>
+      </div>
       {% endfor %}
-    </ul>
+    </div>
   </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- adjust dark theme text colors for higher contrast
- remove scrollbars from mixed folder lists
- show media files in a thumbnail grid
- add styles for the new file management grid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882ab403a9c832b8aee4c07a9c379d9