### PR TITLE
Stay on upload page after media upload

### DIFF
--- a/echoview/web/routes.py
+++ b/echoview/web/routes.py
@@ -243,7 +243,7 @@ def upload_media():
         f.save(final_path)
         log_message(f"Uploaded file: {final_path}")
 
-    return redirect(url_for("main.index"))
+    return redirect(url_for("main.upload_media"))
 
 @main_bp.route("/restart_viewer", methods=["POST"])
 def restart_viewer():


### PR DESCRIPTION
## Summary
- fix `upload_media` redirect to keep user on the upload page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688534e8a8e4832bb85feb7878ce3074