### PR TITLE
Improve media manager readability and sorting

### DIFF
--- a/echoview/web/routes.py
+++ b/echoview/web/routes.py
@@ -213,14 +213,31 @@ def upload_media():
     cfg = load_config()
     theme = cfg.get("theme", "dark")
     if request.method == "GET":
+        sort_opt = request.args.get("sort", "name_asc")
         folder_files = {}
         for sf in get_subfolders():
             try:
                 folder_path = os.path.join(IMAGE_DIR, sf)
-                folder_files[sf] = [f for f in os.listdir(folder_path) if f.lower().endswith((".jpg",".jpeg",".png",".gif"))]
+                files = [
+                    f for f in os.listdir(folder_path)
+                    if f.lower().endswith((".jpg", ".jpeg", ".png", ".gif"))
+                ]
+                if sort_opt.startswith("name"):
+                    files.sort(reverse=(sort_opt == "name_desc"))
+                else:
+                    files.sort(
+                        key=lambda x: os.path.getmtime(os.path.join(folder_path, x)),
+                        reverse=(sort_opt == "date_desc")
+                    )
+                folder_files[sf] = files
             except Exception:
                 folder_files[sf] = []
-        return render_template("upload_media.html", theme=theme, folder_files=folder_files)
+        return render_template(
+            "upload_media.html",
+            theme=theme,
+            folder_files=folder_files,
+            sort_option=sort_opt,
+        )
 
     files = request.files.getlist("mediafiles")
     if not files:

--- a/echoview/web/static/style.css
+++ b/echoview/web/static/style.css
@@ -336,6 +336,10 @@ table td button {
   font-weight: bold;
   cursor: pointer;
   margin-bottom: 10px;
+  color: var(--text-normal);
+}
+#file-manager .filename {
+  color: var(--text-normal);
 }
 #file-manager .upload-thumb {
   width: 100%;

--- a/echoview/web/templates/upload_media.html
+++ b/echoview/web/templates/upload_media.html
@@ -7,6 +7,15 @@
     <input type="text" name="folder_name" placeholder="New Folder Name">
     <button type="submit">Create Folder</button>
   </form>
+  <form method="get" action="{{ url_for('main.upload_media') }}" style="margin-bottom:10px;">
+    <label for="sort_select">Sort:</label>
+    <select id="sort_select" name="sort" onchange="this.form.submit()">
+      <option value="name_asc" {% if sort_option == 'name_asc' %}selected{% endif %}>Name (A-Z)</option>
+      <option value="name_desc" {% if sort_option == 'name_desc' %}selected{% endif %}>Name (Z-A)</option>
+      <option value="date_desc" {% if sort_option == 'date_desc' %}selected{% endif %}>Date Added (Newest)</option>
+      <option value="date_asc" {% if sort_option == 'date_asc' %}selected{% endif %}>Date Added (Oldest)</option>
+    </select>
+  </form>
   {% for folder, files in folder_files.items() %}
   <details class="card">
     <summary>{{ folder }}</summary>


### PR DESCRIPTION
## Summary
- allow sorting media files by name or date
- show sort dropdown in media manager
- ensure folder and file names use normal theme text color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68853b2d0388832bb72e46a233296bdc