### PR TITLE
Implement soft update option

### DIFF
--- a/echoview/web/templates/settings.html
+++ b/echoview/web/templates/settings.html
@@ -68,11 +68,16 @@
 
   <!-- Update from GitHub, logs, reset config, etc. as a final card -->
   <div class="card" style="margin-top:20px;">
+    <p><strong>Update from GitHub</strong></p>
+    <p>Branch: <em>{{ update_branch }}</em></p>
     <form method="POST" action="{{ url_for('main.update_app') }}">
-      <p><strong>Update from GitHub</strong></p>
-      <p>Branch: <em>{{ update_branch }}</em></p>
-      <button type="submit">Update Now</button>
+      <button type="submit">Update</button>
     </form>
+    <p style="font-size:smaller; margin-bottom:10px;">Pull latest code and restart services.</p>
+    <form method="POST" action="{{ url_for('main.full_update') }}">
+      <button type="submit">Full Update &amp; Reboot</button>
+    </form>
+    <p style="font-size:smaller;">Reset to branch, run setup if needed and reboot the device.</p>
     <hr>
     <p style="margin-top:10px;">
       <a href="{{ url_for('main.download_log') }}"><button>Download Log</button></a>

--- a/echoview/web/templates/update_complete.html
+++ b/echoview/web/templates/update_complete.html
@@ -8,8 +8,8 @@
 </head>
 <body>
     <h1>Update Complete</h1>
-    <p>Your application has been updated from GitHub. You can now restart the service.</p>
-    <!-- Option A: Automatic redirect after 5 seconds -->
+    <p>Your application has been updated from GitHub. Services will restart shortly.</p>
+    <!-- Automatic redirect after 5 seconds -->
     <script>
         setTimeout(function() {
             window.location.href = "{{ url_for('main.restart_services') }}";


### PR DESCRIPTION
## Summary
- add new 'update_app' route for soft updates
- move previous update logic to 'full_update' for reboot
- tweak update completion message
- update settings page with two update options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68854239be7c832b861a7958257aadf4