### PR TITLE
Ensure QtWebEngine libs present

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ sudo ./setup.sh
 During the setup:
 
 - **Apt packages** are installed (LightDM, Xorg, Python3, etc.)
+- **WebEngine libs** like `libwebp7`, `libtiff6`, `libxslt1.1`, and `libminizip1t64` are installed,
+  with compatibility symlinks created for `libwebp.so.6` and `libtiff.so.5` if needed.
 - **pip packages** from `dependencies.txt` (or `requirements.txt`) are installed
 - **Screen blanking** is disabled
 - You’ll be prompted for the user that will auto-login into X, the path for `VIEWER_HOME` and `IMAGE_DIR`.
@@ -144,6 +146,8 @@ sudo journalctl -u controller.service
 - **Wrong screen**? Confirm you have multiple monitors recognized by X. EchoView uses PySide6’s screen geometry, so make sure your environment is not on Wayland.
 - **Spotify issues**? Check the file specified by `SPOTIFY_CACHE_PATH` for the saved token. Re-authorize if needed.
 - **Overlay not transparent?** You need a compositor (like **picom**) running for real transparency.
+- **Web viewer blank?** Ensure the system libraries `libxslt1.1` and `libminizip1t64`
+  are installed and that symlinks exist for `libwebp.so.6` and `libtiff.so.5`.
 - **Check logs**: Look at `echoview.log` (in your `VIEWER_HOME`) or `journalctl -u echoview.service`.
 
 ## Contributing

--- a/setup.sh
+++ b/setup.sh
@@ -132,12 +132,32 @@ apt-get install -y \
   libxtst6 \
   libxkbcommon0 \
   libxkbfile1 \
-  libasound2
+  libasound2 \
+  libxslt1.1 \
+  libminizip1t64 \
+  libwebp7 \
+  libtiff6
 
 if [ $? -ne 0 ]; then
   echo "Error installing packages via apt. Exiting."
   exit 1
 fi
+
+# -------------------------------------------------------
+# Ensure PySide6 WebEngine libraries exist
+# -------------------------------------------------------
+# Create compatibility symlinks if older versions are missing
+for LIB in libwebp.so.6 libtiff.so.5; do
+  if ! find /usr/lib -name "$LIB" | grep -q .; then
+    TARGET=$(find /usr/lib -name "${LIB%.so.*}.so.*" | head -n1)
+    if [ -n "$TARGET" ]; then
+      ln -s "$TARGET" "$(dirname "$TARGET")/$LIB"
+    fi
+  fi
+done
+
+# Ensure required runtime libs are installed
+ldconfig
 
 # Create /var/lib/lightdm/data so LightDM can store user-data:
 mkdir -p /var/lib/lightdm/data


### PR DESCRIPTION
## Summary
- update install script with Qt WebEngine runtime packages
- create libwebp/libtiff symlinks if needed
- document additional packages in the README and mention troubleshooting tip

## Testing
- `pip install -r dependencies.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688561afd6bc832b835f3626deb4ba2e