### PR TITLE
feat: add responsive sidebar navigation

### DIFF
--- a/echoview/web/routes.py
+++ b/echoview/web/routes.py
@@ -410,6 +410,15 @@ def settings():
             version=APP_VERSION
         )
 
+@main_bp.route('/toggle_theme', methods=['POST'])
+def toggle_theme():
+    """Quickly switch between dark and light themes and redirect back."""
+    cfg = load_config()
+    current = cfg.get('theme', 'dark')
+    cfg['theme'] = 'light' if current == 'dark' else 'dark'
+    save_config(cfg)
+    return redirect(request.form.get('return_to') or url_for('main.index'))
+
 @main_bp.route("/clear_config", methods=["POST"])
 def clear_config():
     """

--- a/echoview/web/static/script.js
+++ b/echoview/web/static/script.js
@@ -242,3 +242,14 @@ function onMonitorChange() {
   const selForm = document.getElementById("monitorSelectForm");
   if (selForm) selForm.submit();
 }
+
+// Mobile sidebar toggle
+window.addEventListener('DOMContentLoaded', () => {
+  const navToggle = document.getElementById('nav-toggle');
+  const sidebar = document.querySelector('.sidebar');
+  if (navToggle && sidebar) {
+    navToggle.addEventListener('click', () => {
+      sidebar.classList.toggle('open');
+    });
+  }
+});

--- a/echoview/web/static/style.css
+++ b/echoview/web/static/style.css
@@ -338,6 +338,97 @@ table td button {
   text-align: center;
 }
 
+/* --------------------------------------------------------------
+   Sidebar and responsive layout
+   -------------------------------------------------------------- */
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 220px;
+  background: var(--nav-bg);
+  color: var(--nav-fg);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s ease;
+  z-index: 1000;
+}
+.sidebar a.nav-link {
+  color: var(--nav-fg);
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  font-size: 0.95rem;
+  text-decoration: none;
+}
+.sidebar a.nav-link:hover {
+  background: var(--nav-hover);
+}
+.sidebar a.nav-link.active {
+  background: var(--nav-active);
+  color: var(--nav-active-fg);
+}
+.sidebar .dropdown-item {
+  background: transparent;
+  border: none;
+  padding: 0.5rem 0;
+  text-align: left;
+  color: inherit;
+}
+
+.top-bar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  background: var(--nav-bg);
+  color: var(--nav-fg);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 900;
+}
+.top-bar #nav-toggle {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 1.25rem;
+}
+
+main.content {
+  margin-left: 0;
+  margin-top: 0;
+  padding: 1rem;
+  display: block;
+}
+
+/* Mobile behaviour: hide sidebar off-canvas */
+@media (max-width: 767.98px) {
+  .sidebar {
+    transform: translateX(-100%);
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+  main.content {
+    padding-top: 56px;
+  }
+}
+
+/* Desktop: sidebar visible */
+@media (min-width: 768px) {
+  main.content {
+    margin-left: 220px;
+  }
+  .top-bar {
+    display: none;
+  }
+}
+
 #file-manager .file-thumb {
   width: 100%;
   height: 120px;

--- a/echoview/web/templates/base.html
+++ b/echoview/web/templates/base.html
@@ -1,92 +1,56 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}EchoView{% endblock %}</title>
-  <!-- Set tab icon to icon.png -->
   <link rel="icon" href="{{ url_for('static', filename='icon.png') }}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="{{ theme }}-theme">
 
-<!-- Top Navigation Bar -->
-<nav class="top-nav">
-  <!-- Left icon -->
-  <div class="nav-item">
-    <img src="{{ url_for('static', filename='icon.png') }}" alt="Icon" style="height:40px;">
-  </div>
+  <!-- Mobile top bar with hamburger -->
+  <header class="top-bar d-md-none">
+    <button class="btn btn-link" id="nav-toggle" aria-label="Open menu"><i class="fa fa-bars"></i></button>
+    <span class="ms-2 fw-bold">EchoView</span>
+  </header>
 
-  <!-- Display Settings -->
-  <div class="nav-item">
-    <a href="{{ url_for('main.index') }}#local-displays"
-       class="{% if request.endpoint == 'main.index' %}active{% endif %}">
-      ⚙️ Display Settings
-    </a>
-  </div>
-
-  <!-- Media Management -->
-  <div class="nav-item">
-    <a href="{{ url_for('main.upload_media') }}"
-       class="{% if request.endpoint == 'main.upload_media' %}active{% endif %}">
-      📷 Media
-    </a>
-  </div>
-
-  <!-- Spotify -->
-  <div class="nav-item">
-    <a href="{{ url_for('main.configure_spotify') }}"
-       class="{% if request.endpoint == 'main.configure_spotify' %}active{% endif %}">
-      🎶 Spotify
-    </a>
-  </div>
-
-  <!-- Overlay Settings -->
-  <div class="nav-item">
-    <a href="{{ url_for('main.overlay_config') }}"
-       class="{% if request.endpoint == 'main.overlay_config' %}active{% endif %}">
-      🖥️ Overlay
-    </a>
-  </div>
-
-
-  <!-- Settings -->
-  <div class="nav-item">
-    <a href="{{ url_for('main.settings') }}"
-       class="{% if request.endpoint == 'main.settings' %}active{% endif %}">
-      🛠️ Settings
-    </a>
-  </div>
-
-  <!-- Power Button Dropdown -->
-  <div class="nav-item dropdown">
-    <button class="dropbtn">⚡Power</button>
-    <div class="dropdown-content">
-      <form action="{{ url_for('main.restart_viewer') }}" method="post">
-        <button type="submit">Restart Viewer</button>
-      </form>
-      <form action="{{ url_for('main.restart_device') }}" method="post">
-        <button type="submit">Restart Device</button>
-      </form>
-      <form action="{{ url_for('main.power_off') }}" method="post">
-        <button type="submit">Power Off</button>
-      </form>
+  <!-- Sidebar navigation -->
+  <aside class="sidebar">
+    <div class="sidebar-brand d-flex align-items-center mb-3">
+      <img src="{{ url_for('static', filename='icon.png') }}" alt="EchoView" class="me-2" style="height:32px;">
+      <span class="fw-bold">EchoView</span>
     </div>
-  </div>
+    <nav>
+      <ul class="nav flex-column">
+        <li class="nav-item"><a class="nav-link {% if request.endpoint == 'main.index' %}active{% endif %}" href="{{ url_for('main.index') }}"><i class="fa fa-tv me-2"></i>Displays</a></li>
+        <li class="nav-item"><a class="nav-link {% if request.endpoint == 'main.upload_media' %}active{% endif %}" href="{{ url_for('main.upload_media') }}"><i class="fa fa-image me-2"></i>Media</a></li>
+        <li class="nav-item"><a class="nav-link {% if request.endpoint == 'main.configure_spotify' %}active{% endif %}" href="{{ url_for('main.configure_spotify') }}"><i class="fa-brands fa-spotify me-2"></i>Spotify</a></li>
+        <li class="nav-item"><a class="nav-link {% if request.endpoint == 'main.overlay_config' %}active{% endif %}" href="{{ url_for('main.overlay_config') }}"><i class="fa fa-layer-group me-2"></i>Overlay</a></li>
+        <li class="nav-item"><a class="nav-link {% if request.endpoint == 'main.settings' %}active{% endif %}" href="{{ url_for('main.settings') }}"><i class="fa fa-sliders-h me-2"></i>Settings</a></li>
+      </ul>
+      <div class="mt-auto">
+        <form action="{{ url_for('main.restart_viewer') }}" method="post"><button class="dropdown-item w-100" type="submit"><i class="fa fa-sync me-2"></i>Restart Viewer</button></form>
+        <form action="{{ url_for('main.restart_device') }}" method="post"><button class="dropdown-item w-100" type="submit"><i class="fa fa-redo me-2"></i>Restart Device</button></form>
+        <form action="{{ url_for('main.power_off') }}" method="post"><button class="dropdown-item w-100 text-danger" type="submit"><i class="fa fa-power-off me-2"></i>Shut Down</button></form>
+      </div>
+    </nav>
+    <!-- Theme toggle -->
+    <form method="post" action="{{ url_for('main.toggle_theme') }}" class="mt-3 d-flex align-items-center">
+      <input type="hidden" name="return_to" value="{{ request.path }}">
+      <span class="me-2">Theme</span>
+      <button type="submit" class="btn btn-sm btn-outline-secondary"><i class="fa fa-moon"></i></button>
+    </form>
+  </aside>
 
-  <!-- Right icon (flipped) -->
-  <div class="nav-item">
-    <img src="{{ url_for('static', filename='icon.png') }}" alt="Icon" style="height:40px; transform: scaleX(-1);">
-  </div>
-</nav>
+  <!-- Main content -->
+  <main class="content">{% block content %}{% endblock %}</main>
 
-<main class="content">
-  {% block content %}{% endblock %}
-</main>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-<script src="{{ url_for('static', filename='script.js') }}"></script>
-{% block extra_scripts %}{% endblock %}
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='script.js') }}"></script>
+  {% block extra_scripts %}{% endblock %}
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- implement Font Awesome-powered sidebar navigation for clearer labels and always-visible access
- add CSS/JS for responsive sidebar with mobile hamburger and quick theme toggle
- provide Flask endpoint to switch between light and dark themes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e3526231c832bb2c793eafd2008dc