### PR TITLE
feat: add menu for media actions

### DIFF
--- a/echoview/web/static/script.js
+++ b/echoview/web/static/script.js
@@ -253,3 +253,20 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+
+// Toggle per-file action menus in media manager
+function toggleFileMenu(btn) {
+  const item = btn.closest('.file-item');
+  if (item) {
+    item.classList.toggle('open');
+  }
+}
+
+// Close any open file menus when clicking outside
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('.file-item')) {
+    document.querySelectorAll('#file-manager .file-item.open').forEach(el => {
+      el.classList.remove('open');
+    });
+  }
+});

--- a/echoview/web/static/style.css
+++ b/echoview/web/static/style.css
@@ -336,6 +336,65 @@ table td button {
 
 #file-manager .file-item {
   text-align: center;
+  position: relative;
+}
+
+#file-manager .file-options-btn {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: rgba(0,0,0,0.5);
+  border: none;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#file-manager .file-options-menu {
+  display: none;
+  position: absolute;
+  top: 25px;
+  right: 5px;
+  background: var(--dropdown-bg);
+  color: var(--nav-fg);
+  min-width: 140px;
+  box-shadow: 0 8px 16px rgba(0,0,0,0.2);
+  z-index: 20;
+  border-radius: 4px;
+  padding: 5px 0;
+}
+
+#file-manager .file-options-menu form {
+  margin: 0;
+  padding: 0;
+}
+
+#file-manager .file-options-menu a,
+#file-manager .file-options-menu button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 5px 10px;
+  color: inherit;
+  cursor: pointer;
+}
+
+#file-manager .file-options-menu a:hover,
+#file-manager .file-options-menu button:hover {
+  background: var(--dropdown-hover-bg);
+}
+
+#file-manager .file-options-menu input,
+#file-manager .file-options-menu select {
+  width: calc(100% - 20px);
+  margin: 5px 10px;
+}
+
+#file-manager .file-item.open .file-options-menu {
+  display: block;
 }
 
 /* --------------------------------------------------------------

--- a/echoview/web/templates/upload_media.html
+++ b/echoview/web/templates/upload_media.html
@@ -32,28 +32,31 @@
       {% for f in files %}
       <div class="file-item">
         <img src="/thumb/{{ folder }}/{{ f }}?size=120" class="file-thumb" loading="lazy">
+        <button type="button" class="file-options-btn" onclick="toggleFileMenu(this)">⋮</button>
+        <div class="file-options-menu">
+          <form method="post" action="{{ url_for('main.rename_image') }}">
+            <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
+            <input type="text" name="new_name" placeholder="rename">
+            <button type="submit">Rename</button>
+          </form>
+          <form method="post" action="{{ url_for('main.delete_image') }}">
+            <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
+            <button type="submit">Delete</button>
+          </form>
+          <a href="{{ url_for('main.download_file', filename=folder ~ '/' ~ f) }}">Download</a>
+          <form method="post" action="{{ url_for('main.move_image') }}">
+            <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
+            <select name="dest">
+              {% for dest in subfolders %}
+                {% if dest != folder %}
+                  <option value="{{ dest }}">{{ dest }}</option>
+                {% endif %}
+              {% endfor %}
+            </select>
+            <button type="submit">Move</button>
+          </form>
+        </div>
         <div class="filename" style="word-break:break-all;">{{ f }}</div>
-        <form method="post" action="{{ url_for('main.rename_image') }}" class="d-inline">
-          <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
-          <input type="text" name="new_name" placeholder="rename">
-          <button type="submit">Rename</button>
-        </form>
-        <form method="post" action="{{ url_for('main.delete_image') }}" class="d-inline">
-          <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
-          <button type="submit">Delete</button>
-        </form>
-        <a href="{{ url_for('main.download_file', filename=folder ~ '/' ~ f) }}">Download</a>
-        <form method="post" action="{{ url_for('main.move_image') }}" class="d-inline">
-          <input type="hidden" name="path" value="{{ folder }}/{{ f }}">
-          <select name="dest">
-            {% for dest in subfolders %}
-              {% if dest != folder %}
-                <option value="{{ dest }}">{{ dest }}</option>
-              {% endif %}
-            {% endfor %}
-          </select>
-          <button type="submit">Move</button>
-        </form>
       </div>
       {% endfor %}
       <div class="file-item">


### PR DESCRIPTION
## Summary
- add thumbnail-level menu for rename, delete, download, and move
- style file manager action menu to match other dropdowns
- support menu toggle/close behavior in JS

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e42d973dc832bac171900458f9271