### PR TITLE
Add video support and rename media modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # EchoView
 
-EchoView is a modern, easy-to-configure slideshow + overlay viewer written in **Python/PySide6** along with a companion **Flask**-based web interface. It seamlessly supports multiple monitors on a Raspberry Pi and can optionally display a live overlay (e.g. clock) on top of your images or GIFs.
+EchoView is a modern, easy-to-configure slideshow + overlay viewer written in **Python/PySide6** along with a companion **Flask**-based web interface. It seamlessly supports multiple monitors on a Raspberry Pi and can optionally display a live overlay (e.g. clock) on top of your images, GIFs, or videos.
 
 ## Key Features
 
-- **Multiple Monitors**: Launches a PySide6 window per detected monitor, each with its own display mode (Random, Mixed, Spotify, Web Page, etc.).
+- **Multiple Monitors**: Launches a PySide6 window per detected monitor, each with its own display mode (Random Media, Mixed Media, Spotify, Web Page, etc.).
 - **Web Controller**: A Flask web interface (on port **8080**) lets you manage sub-devices, change the slideshow folder, set intervals, shuffle, or pick a single image.
 - **Systemd Integration**: The `setup.sh` script creates two systemd services:
   - `echoview.service` - runs the PySide6 slideshow windows
@@ -61,9 +61,9 @@ Browse to `http://<PI-IP>:8080` to access the interface. You’ll see:
 
 - **Main Screen** (`index.html`)
   - Displays system stats (CPU, memory, temp)
-  - Lets you configure each local display’s mode (Random, Specific, Mixed, or Spotify)
-  - For Specific mode, choose exactly one image. For Mixed, drag-drop multiple folders.
-  - **Manage** how often images rotate, shuffle, etc.
+  - Lets you configure each local display’s mode (Random Media, Specific Media, Mixed Media, or Spotify)
+  - For Specific mode, choose exactly one media file. For Mixed, drag-drop multiple folders.
+  - **Manage** how often media files rotate, shuffle, etc.
 
 - **Settings** Page
   - Set the web theme (Dark, Light, or Custom) and optionally upload a background image
@@ -85,8 +85,8 @@ You can override the path by adding `SPOTIFY_CACHE_PATH` to your `.env` file.
 
 ### Media Upload
 
-Use the **Upload Media** page to add images/GIFs. You can place them in existing subfolders or create a new one. If you have a CIFS share, it will appear under your `IMAGE_DIR`.
-The file manager also lets you download images and move them between folders. Folders are always shown alphabetically for easier navigation.
+Use the **Upload Media** page to add images, GIFs, or videos. You can place them in existing subfolders or create a new one. If you have a CIFS share, it will appear under your `IMAGE_DIR`.
+The file manager also lets you download files and move them between folders. Folders are always shown alphabetically for easier navigation.
 
 
 ## Directory Structure
@@ -154,7 +154,7 @@ If a `.env` file already exists in your `VIEWER_HOME`, its `VIEWER_HOME` and
 
 ## Troubleshooting
 
-- **No images?** Ensure images exist in the `IMAGE_DIR` (or subfolders). By default, check `/mnt/EchoViews` or wherever you mounted.
+- **No media?** Ensure files exist in the `IMAGE_DIR` (or subfolders). By default, check `/mnt/EchoViews` or wherever you mounted.
 - **Wrong screen**? Confirm you have multiple monitors recognized by X. EchoView uses PySide6’s screen geometry, so make sure your environment is not on Wayland.
 - **Spotify issues**? Check the file specified by `SPOTIFY_CACHE_PATH` for the saved token. Re-authorize if needed.
 - **Overlay not transparent?** You need a compositor (like **picom**) running for real transparency.

--- a/echoview/utils.py
+++ b/echoview/utils.py
@@ -164,7 +164,7 @@ def count_files_in_folder(folder_path):
     if not os.path.isdir(folder_path):
         return 0
     cnt = 0
-    valid_ext = (".png", ".jpg", ".jpeg", ".gif")
+    valid_ext = (".png", ".jpg", ".jpeg", ".gif", ".mp4", ".mov", ".avi", ".mkv", ".webm")
     for f in os.listdir(folder_path):
         if f.lower().endswith(valid_ext):
             cnt += 1

--- a/echoview/viewer.py
+++ b/echoview/viewer.py
@@ -25,6 +25,8 @@ from PySide6.QtWidgets import (
     QGraphicsScene, QGraphicsPixmapItem, QGraphicsBlurEffect, QSizePolicy
 )
 from PySide6.QtWebEngineWidgets import QWebEngineView
+from PySide6.QtMultimedia import QMediaPlayer, QAudioOutput
+from PySide6.QtMultimediaWidgets import QVideoWidget
 
 from spotipy.oauth2 import SpotifyOAuth
 from echoview.config import APP_VERSION, IMAGE_DIR, LOG_PATH, VIEWER_HOME, SPOTIFY_CACHE_PATH
@@ -128,6 +130,16 @@ class DisplayWindow(QMainWindow):
         self.foreground_label.setAlignment(Qt.AlignCenter)
         self.foreground_label.setStyleSheet("background-color: transparent;")
 
+        # Video widget for mp4 and other videos (muted)
+        self.video_widget = QVideoWidget(self.main_widget)
+        self.video_widget.hide()
+        self.audio_output = QAudioOutput()
+        self.audio_output.setVolume(0)
+        self.media_player = QMediaPlayer()
+        self.media_player.setVideoOutput(self.video_widget)
+        self.media_player.setAudioOutput(self.audio_output)
+        self.media_player.mediaStatusChanged.connect(self.on_video_status_changed)
+
         # Overlay label for clock
         self.clock_label = NegativeTextLabel(self.main_widget)
         self.clock_label.setText("00:00:00")
@@ -181,6 +193,7 @@ class DisplayWindow(QMainWindow):
 
         self.bg_label.setGeometry(rect)
         self.foreground_label.setGeometry(rect)
+        self.video_widget.setGeometry(rect)
         if self.web_view.isVisible():
             self.web_view.setGeometry(rect)
             self.web_view.lower()
@@ -375,16 +388,16 @@ class DisplayWindow(QMainWindow):
         self.image_list = []
         self.index = 0
         if self.current_mode in ("random_image", "mixed", "specific_image"):
-            self.build_local_image_list()
+            self.build_local_media_list()
 
         if self.current_mode == "spotify":
             self.next_image(force=True)
 
-    def build_local_image_list(self):
+    def build_local_media_list(self):
         mode = self.current_mode
         if mode == "random_image":
             cat = self.disp_cfg.get("image_category", "")
-            images = self.gather_images(cat)
+            images = self.gather_media(cat)
             if self.disp_cfg.get("shuffle_mode", False):
                 random.shuffle(images)
             self.image_list = images
@@ -392,7 +405,7 @@ class DisplayWindow(QMainWindow):
             folder_list = self.disp_cfg.get("mixed_folders", [])
             allimg = []
             for folder in folder_list:
-                allimg += self.gather_images(folder)
+                allimg += self.gather_media(folder)
             if self.disp_cfg.get("shuffle_mode", False):
                 random.shuffle(allimg)
             self.image_list = allimg
@@ -406,20 +419,22 @@ class DisplayWindow(QMainWindow):
                 log_message(f"Specific image not found: {path}")
                 self.image_list = []
 
-    def gather_images(self, category):
+    def gather_media(self, category):
         base = os.path.join(IMAGE_DIR, category) if category else IMAGE_DIR
         if not os.path.isdir(base):
             return []
         results = []
         for fname in os.listdir(base):
             lf = fname.lower()
-            if lf.endswith((".jpg", ".jpeg", ".png", ".gif")):
+            if lf.endswith((".jpg", ".jpeg", ".png", ".gif", ".mp4", ".mov", ".avi", ".mkv", ".webm")):
                 results.append(os.path.join(base, fname))
         results.sort()
         return results
 
-    def load_and_cache_image(self, fullpath):
+    def load_and_cache_media(self, fullpath):
         ext = os.path.splitext(fullpath)[1].lower()
+        if ext in (".mp4", ".mov", ".avi", ".mkv", ".webm"):
+            return {"type": "video", "path": fullpath}
         if ext == ".gif":
             tmp_reader = QImageReader(fullpath)
             tmp_reader.setAutoDetectImageFormat(True)
@@ -429,11 +444,11 @@ class DisplayWindow(QMainWindow):
             pixmap = QPixmap(fullpath)
             return {"type": "static", "pixmap": pixmap}
 
-    def get_cached_image(self, fullpath):
+    def get_cached_media(self, fullpath):
         if fullpath in self.image_cache:
             self.image_cache.move_to_end(fullpath)
             return self.image_cache[fullpath]
-        data = self.load_and_cache_image(fullpath)
+        data = self.load_and_cache_media(fullpath)
         self.image_cache[fullpath] = data
         if len(self.image_cache) > self.cache_capacity:
             self.image_cache.popitem(last=False)
@@ -453,7 +468,7 @@ class DisplayWindow(QMainWindow):
         if self.current_mode == "spotify":
             path = self.fetch_spotify_album_art()
             if path:
-                self.show_foreground_image(path, is_spotify=True)
+                self.show_foreground_media(path, is_spotify=True)
                 self.spotify_info_label.show()
                 if self.disp_cfg.get("spotify_show_progress", False):
                     self.spotify_progress_bar.show()
@@ -495,14 +510,14 @@ class DisplayWindow(QMainWindow):
                     image_list_backup = self.image_list
                     mode_backup = self.current_mode
                     self.current_mode = fallback_mode
-                    self.build_local_image_list()
+                    self.build_local_media_list()
                     if not self.image_list:
                         self.clear_foreground_label("No fallback images found")
                     else:
                         self.index = (self.index + 1) % len(self.image_list)
                         new_path = self.image_list[self.index]
                         self.last_displayed_path = new_path
-                        self.show_foreground_image(new_path)
+                        self.show_foreground_media(new_path)
                     self.current_mode = mode_backup
                     self.image_list = image_list_backup
                     self.spotify_info_label.setText("")
@@ -526,7 +541,7 @@ class DisplayWindow(QMainWindow):
         new_path = self.image_list[self.index]
         self.last_displayed_path = new_path
 
-        self.show_foreground_image(new_path)
+        self.show_foreground_media(new_path)
         if self.overlay_config.get("auto_negative_font", False):
             self.clock_label.update()
 
@@ -542,6 +557,13 @@ class DisplayWindow(QMainWindow):
                 pass
             self.current_movie = None
             self.handling_gif_frames = False
+        try:
+            self.media_player.stop()
+        except RuntimeError:
+            pass
+        self.video_widget.hide()
+        self.bg_label.show()
+        self.foreground_label.show()
         self.foreground_label.setMovie(None)
         self.foreground_label.setText(message)
         self.foreground_label.setAlignment(Qt.AlignCenter)
@@ -549,7 +571,7 @@ class DisplayWindow(QMainWindow):
         self.spotify_progress_bar.hide()
         self.spotify_progress_timer.stop()
 
-    def show_foreground_image(self, fullpath, is_spotify=False):
+    def show_foreground_media(self, fullpath, is_spotify=False):
         if not os.path.exists(fullpath):
             self.clear_foreground_label("Missing file")
             return
@@ -565,8 +587,27 @@ class DisplayWindow(QMainWindow):
                 pass
             self.current_movie = None
             self.handling_gif_frames = False
+        try:
+            self.media_player.stop()
+        except RuntimeError:
+            pass
+        self.video_widget.hide()
+        self.bg_label.show()
+        self.foreground_label.show()
 
-        data = self.get_cached_image(fullpath)
+        data = self.get_cached_media(fullpath)
+        if data["type"] == "video" and not is_spotify:
+            self.foreground_label.clear()
+            self.bg_label.clear()
+            self.bg_label.hide()
+            self.foreground_label.hide()
+            self.video_widget.show()
+            self.media_player.setSource(QUrl.fromLocalFile(fullpath))
+            self.media_player.setLoops(1)
+            self.media_player.play()
+            self.spotify_info_label.raise_()
+            self.slideshow_timer.stop()
+            return
         if data["type"] == "gif" and not is_spotify:
             if self.fg_scale_percent == 100:
                 self.current_movie = QMovie(data["path"])
@@ -605,6 +646,18 @@ class DisplayWindow(QMainWindow):
             blurred = self.make_background(self.current_pixmap)
             self.bg_label.setPixmap(blurred if blurred else QPixmap())
         self.spotify_info_label.raise_()
+
+    def on_video_status_changed(self, status):
+        if status == QMediaPlayer.EndOfMedia:
+            self.video_widget.hide()
+            self.bg_label.show()
+            self.foreground_label.show()
+            try:
+                self.media_player.stop()
+            except RuntimeError:
+                pass
+            self.next_image()
+            self.slideshow_timer.start()
 
     def on_gif_frame_changed(self, frame_index):
         if not self.current_movie or not self.handling_gif_frames:

--- a/echoview/web/routes.py
+++ b/echoview/web/routes.py
@@ -246,7 +246,10 @@ def upload_media():
                 folder_path = os.path.join(IMAGE_DIR, sf)
                 files = [
                     f for f in os.listdir(folder_path)
-                    if f.lower().endswith((".jpg", ".jpeg", ".png", ".gif"))
+                    if f.lower().endswith((
+                        ".jpg", ".jpeg", ".png", ".gif",
+                        ".mp4", ".mov", ".avi", ".mkv", ".webm"
+                    ))
                 ]
                 if sort_opt.startswith("name"):
                     files.sort(reverse=(sort_opt == "name_desc"))
@@ -280,7 +283,10 @@ def upload_media():
         if not f.filename:
             continue
         lf = f.filename.lower()
-        if not lf.endswith((".jpg", ".jpeg", ".png", ".gif")):
+        if not lf.endswith((
+            ".jpg", ".jpeg", ".png", ".gif",
+            ".mp4", ".mov", ".avi", ".mkv", ".webm"
+        )):
             log_message(f"Unsupported file type: {f.filename}")
             continue
         final_path = os.path.join(target_dir, f.filename)
@@ -710,7 +716,10 @@ def index():
         if os.path.isdir(base_dir):
             for fname in os.listdir(base_dir):
                 lf = fname.lower()
-                if lf.endswith((".jpg", ".jpeg", ".png", ".gif")):
+                if lf.endswith((
+                    ".jpg", ".jpeg", ".png", ".gif",
+                    ".mp4", ".mov", ".avi", ".mkv", ".webm"
+                )):
                     rel_path = fname
                     img_list.append(os.path.join(cat, rel_path) if cat else rel_path)
         img_list.sort()

--- a/echoview/web/static/script.js
+++ b/echoview/web/static/script.js
@@ -155,21 +155,33 @@ function loadSpecificThumbnails(dispName) {
     const bn = filePath.split("/").pop();
     const lbl = document.createElement("label");
     lbl.className = "thumb-label";
-    const img = document.createElement("img");
-    img.src = "/thumb/" + filePath + "?size=60";
-    img.loading = "lazy";
-    img.style.width = "60px";
-    img.style.height = "60px";
-    img.style.objectFit = "cover";
-    img.style.border = "2px solid #555";
-    img.style.borderRadius = "4px";
-    img.style.margin = "5px";
+    const ext = filePath.split('.').pop().toLowerCase();
+    let thumbEl;
+    if (["mp4","mov","avi","mkv","webm"].includes(ext)) {
+      const vid = document.createElement("video");
+      vid.src = "/images/" + filePath;
+      vid.muted = true;
+      vid.loop = true;
+      vid.autoplay = true;
+      thumbEl = vid;
+    } else {
+      const img = document.createElement("img");
+      img.src = "/thumb/" + filePath + "?size=60";
+      img.loading = "lazy";
+      thumbEl = img;
+    }
+    thumbEl.style.width = "60px";
+    thumbEl.style.height = "60px";
+    thumbEl.style.objectFit = "cover";
+    thumbEl.style.border = "2px solid #555";
+    thumbEl.style.borderRadius = "4px";
+    thumbEl.style.margin = "5px";
     const radio = document.createElement("input");
     radio.type = "radio";
     radio.name = dispName + "_specific_image";
     radio.value = bn;
 
-    lbl.appendChild(img);
+    lbl.appendChild(thumbEl);
     lbl.appendChild(document.createElement("br"));
     lbl.appendChild(radio);
     lbl.appendChild(document.createTextNode(" " + bn));

--- a/echoview/web/templates/index.html
+++ b/echoview/web/templates/index.html
@@ -29,9 +29,9 @@
           <!-- Mode -->
           <label>Mode:</label><br>
           <select name="{{ dname }}_mode">
-            <option value="random_image"   {% if dcfg.mode=="random_image" %}selected{% endif %}>Random Image/GIF</option>
-            <option value="specific_image" {% if dcfg.mode=="specific_image" %}selected{% endif %}>Specific Image/GIF</option>
-            <option value="mixed"          {% if dcfg.mode=="mixed" %}selected{% endif %}>Mixed (Multiple Folders)</option>
+            <option value="random_image"   {% if dcfg.mode=="random_image" %}selected{% endif %}>Random Media</option>
+            <option value="specific_image" {% if dcfg.mode=="specific_image" %}selected{% endif %}>Specific Media</option>
+            <option value="mixed"          {% if dcfg.mode=="mixed" %}selected{% endif %}>Mixed Media (Multiple Folders)</option>
             <option value="spotify"        {% if dcfg.mode=="spotify" %}selected{% endif %}>Spotify Now Playing</option>
             <option value="web_page"       {% if dcfg.mode=="web_page" %}selected{% endif %}>Web Page</option>
           </select>
@@ -40,9 +40,9 @@
           {% if dcfg.mode == "spotify" %}
           <label>Fallback Mode:</label><br>
           <select name="{{ dname }}_fallback_mode">
-            <option value="random_image"   {% if dcfg.fallback_mode=="random_image" %}selected{% endif %}>Random Image/GIF</option>
-            <option value="specific_image" {% if dcfg.fallback_mode=="specific_image" %}selected{% endif %}>Specific Image/GIF</option>
-            <option value="mixed"          {% if dcfg.fallback_mode=="mixed" %}selected{% endif %}>Mixed (Multiple Folders)</option>
+            <option value="random_image"   {% if dcfg.fallback_mode=="random_image" %}selected{% endif %}>Random Media</option>
+            <option value="specific_image" {% if dcfg.fallback_mode=="specific_image" %}selected{% endif %}>Specific Media</option>
+            <option value="mixed"          {% if dcfg.fallback_mode=="mixed" %}selected{% endif %}>Mixed Media (Multiple Folders)</option>
             <option value="none"           {% if dcfg.fallback_mode=="none" %}selected{% endif %}>None</option>
           </select>
           <br><br>
@@ -166,9 +166,9 @@
           </script>
           <br>
           {% endif %}
-          <!-- Specific Image selection -->
+          <!-- Specific Media selection -->
           {% if dcfg.mode == "specific_image" %}
-          <label>Select Image/GIF:</label><br>
+          <label>Select Media:</label><br>
           {% set fileList = display_images[dname] %}
           {% if fileList and fileList|length > 100 %}
             <div id="{{ dname }}_lazyContainer" data-files='{{ fileList|tojson }}'>
@@ -179,8 +179,13 @@
             <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:10px;">
               {% for imgpath in fileList %}
                 {% set bn = imgpath.split('/')[-1] %}
+                {% set ext = bn.split('.')[-1].lower() %}
                 <label style="text-align:center; cursor:pointer;">
-                  <img src="/thumb/{{ imgpath }}?size=60" loading="lazy" style="width:60px; height:60px; object-fit:cover; border:2px solid #555; border-radius:4px;">
+                  {% if ext in ['mp4','mov','avi','mkv','webm'] %}
+                    <video src="/images/{{ imgpath }}" style="width:60px; height:60px; object-fit:cover; border:2px solid #555; border-radius:4px;" muted loop></video>
+                  {% else %}
+                    <img src="/thumb/{{ imgpath }}?size=60" loading="lazy" style="width:60px; height:60px; object-fit:cover; border:2px solid #555; border-radius:4px;">
+                  {% endif %}
                   <br>
                   <input type="radio" name="{{ dname }}_specific_image" value="{{ bn }}"
                          {% if bn == dcfg.specific_image %}checked{% endif %}>
@@ -189,7 +194,7 @@
               {% endfor %}
             </div>
             {% else %}
-              <p>No images found or category is empty. <a href="{{ url_for('main.upload_media') }}">Upload some?</a></p>
+              <p>No media found or category is empty. <a href="{{ url_for('main.upload_media') }}">Upload some?</a></p>
             {% endif %}
           {% endif %}
           <br>

--- a/echoview/web/templates/upload_media.html
+++ b/echoview/web/templates/upload_media.html
@@ -31,7 +31,12 @@
     <div class="folder-grid">
       {% for f in files %}
       <div class="file-item">
+        {% set ext = f.split('.')[-1].lower() %}
+        {% if ext in ['mp4','mov','avi','mkv','webm'] %}
+        <video src="/images/{{ folder }}/{{ f }}" class="file-thumb" muted loop></video>
+        {% else %}
         <img src="/thumb/{{ folder }}/{{ f }}?size=120" class="file-thumb" loading="lazy">
+        {% endif %}
         <button type="button" class="file-options-btn" onclick="toggleFileMenu(this)">⋮</button>
         <div class="file-options-menu">
           <form method="post" action="{{ url_for('main.rename_image') }}">
@@ -64,7 +69,7 @@
           <input type="hidden" name="subfolder" value="{{ folder }}">
           <label class="upload-thumb">
             +
-            <input type="file" name="mediafiles" accept=".gif,.png,.jpg,.jpeg" multiple style="display:none" onchange="this.form.submit()">
+            <input type="file" name="mediafiles" accept=".gif,.png,.jpg,.jpeg,.mp4,.mov,.avi,.mkv,.webm" multiple style="display:none" onchange="this.form.submit()">
           </label>
         </form>
       </div>

--- a/tests/test_spotify_fetch.py
+++ b/tests/test_spotify_fetch.py
@@ -59,6 +59,12 @@ for name in [
 qtweb = types.ModuleType("PySide6.QtWebEngineWidgets")
 qtweb.QWebEngineView = type("QWebEngineView", (), {})
 
+qtmedia = types.ModuleType("PySide6.QtMultimedia")
+qtmedia.QMediaPlayer = type("QMediaPlayer", (), {"EndOfMedia": 0})
+qtmedia.QAudioOutput = type("QAudioOutput", (), {})
+qtmediawidgets = types.ModuleType("PySide6.QtMultimediaWidgets")
+qtmediawidgets.QVideoWidget = type("QVideoWidget", (), {})
+
 spotipy = types.ModuleType("spotipy")
 spotipy.Spotify = type("Spotify", (), {})
 oauth2 = types.ModuleType("spotipy.oauth2")
@@ -70,6 +76,8 @@ sys.modules.setdefault("PySide6.QtCore", qtcore)
 sys.modules.setdefault("PySide6.QtGui", qtgui)
 sys.modules.setdefault("PySide6.QtWidgets", qtwidgets)
 sys.modules.setdefault("PySide6.QtWebEngineWidgets", qtweb)
+sys.modules.setdefault("PySide6.QtMultimedia", qtmedia)
+sys.modules.setdefault("PySide6.QtMultimediaWidgets", qtmediawidgets)
 sys.modules.setdefault("spotipy", spotipy)
 sys.modules.setdefault("spotipy.oauth2", oauth2)
 


### PR DESCRIPTION
## Summary
- allow muted video playback alongside images and GIFs
- treat videos as selectable media and rename modes to *Random Media*, *Specific Media*, etc.
- update media manager and configuration utilities to accept video files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e48c0bf64832b8d1d87425204ed38