### PR TITLE
Support video uploads and sequential playback

### DIFF
--- a/echoview/viewer.py
+++ b/echoview/viewer.py
@@ -214,9 +214,6 @@ class DisplayWindow(QMainWindow):
         if not self.image_list:
             self.clear_foreground_label("No videos found")
             return
-        self.index += 1
-        if self.index >= len(self.image_list):
-            self.index = 0
         path = self.image_list[self.index]
         self.last_displayed_path = path
         if not shutil.which("mpv"):
@@ -240,6 +237,10 @@ class DisplayWindow(QMainWindow):
                 QTimer.singleShot(0, self.next_image)
 
         threading.Thread(target=wait_thread, args=(proc,), daemon=True).start()
+
+        self.index += 1
+        if self.index >= len(self.image_list):
+            self.index = 0
 
         if not self.disp_cfg.get("video_play_to_end", True):
             max_sec = int(self.disp_cfg.get("video_max_seconds", 120))

--- a/echoview/web/routes.py
+++ b/echoview/web/routes.py
@@ -25,6 +25,12 @@ from echoview.utils import (
     CONFIG_PATH
 )
 
+# Supported media file extensions for the upload/file-manager features.
+VALID_MEDIA_EXT = (
+    ".jpg", ".jpeg", ".png", ".gif",
+    ".mp4", ".mov", ".avi", ".mkv", ".webm"
+)
+
 def detect_monitors_extended():
     """
     Calls xrandr --props to find connected monitors, their preferred/current resolution,
@@ -246,7 +252,7 @@ def upload_media():
                 folder_path = os.path.join(IMAGE_DIR, sf)
                 files = [
                     f for f in os.listdir(folder_path)
-                    if f.lower().endswith((".jpg", ".jpeg", ".png", ".gif"))
+                    if f.lower().endswith(VALID_MEDIA_EXT)
                 ]
                 if sort_opt.startswith("name"):
                     files.sort(reverse=(sort_opt == "name_desc"))
@@ -280,7 +286,7 @@ def upload_media():
         if not f.filename:
             continue
         lf = f.filename.lower()
-        if not lf.endswith((".jpg", ".jpeg", ".png", ".gif")):
+        if not lf.endswith(VALID_MEDIA_EXT):
             log_message(f"Unsupported file type: {f.filename}")
             continue
         final_path = os.path.join(target_dir, f.filename)

--- a/echoview/web/templates/upload_media.html
+++ b/echoview/web/templates/upload_media.html
@@ -31,7 +31,11 @@
     <div class="folder-grid">
       {% for f in files %}
       <div class="file-item">
+        {% if f.lower().endswith(('.mp4','.mov','.avi','.mkv','.webm')) %}
+        <video src="/images/{{ folder }}/{{ f }}" class="file-thumb" controls></video>
+        {% else %}
         <img src="/thumb/{{ folder }}/{{ f }}?size=120" class="file-thumb" loading="lazy">
+        {% endif %}
         <button type="button" class="file-options-btn" onclick="toggleFileMenu(this)">⋮</button>
         <div class="file-options-menu">
           <form method="post" action="{{ url_for('main.rename_image') }}">
@@ -64,7 +68,7 @@
           <input type="hidden" name="subfolder" value="{{ folder }}">
           <label class="upload-thumb">
             +
-            <input type="file" name="mediafiles" accept=".gif,.png,.jpg,.jpeg" multiple style="display:none" onchange="this.form.submit()">
+            <input type="file" name="mediafiles" accept=".gif,.png,.jpg,.jpeg,.mp4,.mov,.avi,.mkv,.webm" multiple style="display:none" onchange="this.form.submit()">
           </label>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- Allow video files in web upload manager with new media extension list
- Render videos in file manager and accept video uploads
- Fix mpv playback to advance to the next video sequentially

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fd783c2a4832ba0773888e683e323