### PR TITLE
Handle video advancement and hide unused video inputs

### DIFF
--- a/echoview/viewer.py
+++ b/echoview/viewer.py
@@ -233,8 +233,7 @@ class DisplayWindow(QMainWindow):
         def wait_thread(p):
             p.wait()
             if self.current_video_proc is p:
-                self.current_video_proc = None
-                QTimer.singleShot(0, self.next_image)
+                self.stop_current_video(advance=True)
 
         threading.Thread(target=wait_thread, args=(proc,), daemon=True).start()
 
@@ -244,7 +243,7 @@ class DisplayWindow(QMainWindow):
 
         if not self.disp_cfg.get("video_play_to_end", True):
             max_sec = int(self.disp_cfg.get("video_max_seconds", 120))
-            QTimer.singleShot(max_sec * 1000, self.stop_current_video)
+            QTimer.singleShot(max_sec * 1000, lambda: self.stop_current_video(advance=True))
 
     def build_mpv_command(self, fullpath):
         cmd = [
@@ -269,7 +268,7 @@ class DisplayWindow(QMainWindow):
         cmd += ["--", fullpath]
         return cmd
 
-    def stop_current_video(self):
+    def stop_current_video(self, advance=False):
         proc = self.current_video_proc
         if proc and proc.poll() is None:
             try:
@@ -281,6 +280,8 @@ class DisplayWindow(QMainWindow):
                 except Exception:
                     pass
         self.current_video_proc = None
+        if advance:
+            QTimer.singleShot(0, self.next_image)
 
         # Position Spotify progress bar using its own position setting.
         if self.spotify_progress_bar.isVisible():

--- a/echoview/web/static/script.js
+++ b/echoview/web/static/script.js
@@ -142,6 +142,38 @@ function initMixedUI(dispName) {
   sortAvailable();
 }
 
+// ---- Video play-to-end toggle ----
+function initVideoPlayToEndToggle() {
+  const checkboxes = document.querySelectorAll('.video-play-to-end');
+  checkboxes.forEach(cb => {
+    const prefix = cb.id.replace('_video_play_to_end', '');
+    const container = document.getElementById(prefix + '_max_seconds_container');
+    const toggle = () => {
+      if (!container) return;
+      container.style.display = cb.checked ? 'none' : 'block';
+    };
+    cb.addEventListener('change', toggle);
+    toggle();
+  });
+}
+window.addEventListener('DOMContentLoaded', initVideoPlayToEndToggle);
+
+// ---- Video mute toggle ----
+function initVideoMuteToggle() {
+  const checkboxes = document.querySelectorAll('.video-mute');
+  checkboxes.forEach(cb => {
+    const prefix = cb.id.replace('_video_mute', '');
+    const container = document.getElementById(prefix + '_volume_container');
+    const toggle = () => {
+      if (!container) return;
+      container.style.display = cb.checked ? 'none' : 'block';
+    };
+    cb.addEventListener('change', toggle);
+    toggle();
+  });
+}
+window.addEventListener('DOMContentLoaded', initVideoMuteToggle);
+
 // ---- Lazy load thumbnails for specific_image mode ----
 function loadSpecificThumbnails(dispName) {
   const container = document.getElementById(dispName + "_lazyContainer");

--- a/echoview/web/templates/index.html
+++ b/echoview/web/templates/index.html
@@ -202,17 +202,21 @@
           </select>
           <br><br>
           <label>Mute by Default:</label>
-          <input type="checkbox" name="{{ dname }}_video_mute" value="1" {% if dcfg.video_mute is not defined or dcfg.video_mute %}checked{% endif %}>
+          <input type="checkbox" name="{{ dname }}_video_mute" id="{{ dname }}_video_mute" class="video-mute" value="1" {% if dcfg.video_mute is not defined or dcfg.video_mute %}checked{% endif %}>
           <br><br>
-          <label>Volume:</label>
-          <input type="number" name="{{ dname }}_video_volume" value="{{ dcfg.video_volume|default(100) }}" min="0" max="100" style="width:60px;">
-          <br><br>
+          <div id="{{ dname }}_volume_container">
+            <label>Volume:</label>
+            <input type="number" name="{{ dname }}_video_volume" value="{{ dcfg.video_volume|default(100) }}" min="0" max="100" style="width:60px;">
+            <br><br>
+          </div>
           <label>Play to End:</label>
-          <input type="checkbox" name="{{ dname }}_video_play_to_end" value="1" {% if dcfg.video_play_to_end is not defined or dcfg.video_play_to_end %}checked{% endif %}>
+          <input type="checkbox" name="{{ dname }}_video_play_to_end" id="{{ dname }}_video_play_to_end" class="video-play-to-end" value="1" {% if dcfg.video_play_to_end is not defined or dcfg.video_play_to_end %}checked{% endif %}>
           <br><br>
-          <label>Max play seconds:</label>
-          <input type="number" name="{{ dname }}_video_max_seconds" value="{{ dcfg.video_max_seconds|default(120) }}" style="width:80px;">
-          <br><br>
+          <div id="{{ dname }}_max_seconds_container">
+            <label>Max play seconds:</label>
+            <input type="number" name="{{ dname }}_video_max_seconds" value="{{ dcfg.video_max_seconds|default(120) }}" style="width:80px;">
+          </div>
+          <br>
           {% endif %}
           <!-- Specific Image selection -->
           {% if dcfg.mode == "specific_image" %}

--- a/tests/test_video_mode.py
+++ b/tests/test_video_mode.py
@@ -107,6 +107,14 @@ def test_build_mpv_command_volume(monkeypatch):
     assert "--volume=55" in cmd
 
 
+def test_build_mpv_command_mute(monkeypatch):
+    dw = DisplayWindow.__new__(DisplayWindow)
+    dw.disp_cfg = {"video_mute": True, "video_volume": 55}
+    cmd = DisplayWindow.build_mpv_command(dw, "/tmp/test.mp4")
+    assert "--mute=yes" in cmd
+    assert "--volume=0" in cmd
+
+
 def test_play_next_video_sequential(monkeypatch):
     dw = DisplayWindow.__new__(DisplayWindow)
     dw.disp_cfg = {"video_play_to_end": True}
@@ -140,3 +148,22 @@ def test_play_next_video_sequential(monkeypatch):
 
     assert played == ["a.mp4"]
     assert dw.index == 1
+
+
+def test_stop_current_video_advances(monkeypatch):
+    dw = DisplayWindow.__new__(DisplayWindow)
+    dummy_proc = types.SimpleNamespace(poll=lambda: 0)
+    dw.current_video_proc = dummy_proc
+    advanced = []
+    dw.next_image = lambda force=False: advanced.append("next")
+    dw.spotify_progress_bar = types.SimpleNamespace(isVisible=lambda: False)
+    dw.disp_cfg = {}
+    dw.spotify_info_label = types.SimpleNamespace(x=lambda: 0, y=lambda: 0, width=lambda: 0, height=lambda: 0)
+    dw.clock_label = types.SimpleNamespace(isVisible=lambda: False)
+    dw.overlay_config = {}
+    dw.current_pixmap = None
+    dw.handling_gif_frames = False
+    dw.current_movie = None
+    dw.bg_label = types.SimpleNamespace(setPixmap=lambda *a, **k: None)
+    DisplayWindow.stop_current_video(dw, advance=True)
+    assert advanced == ["next"]


### PR DESCRIPTION
## Summary
- Hide "Max play seconds" input when "Play to End" is enabled
- Hide volume control when "Mute by Default" is selected
- Automatically advance to the next video when playback finishes or max duration expires
- Add regression tests for video advancement and mute behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fdd3d72f4832ba591e9be1f4b7d08