### PR TITLE
Fix config save to prevent server error on missing home dir

### DIFF
--- a/echoview/utils.py
+++ b/echoview/utils.py
@@ -88,10 +88,12 @@ def load_config():
         return json.load(f)
 
 def save_config(cfg):
+    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
     with open(CONFIG_PATH, "w") as f:
         json.dump(cfg, f, indent=2)
 
 def log_message(msg):
+    os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
     with open(LOG_PATH, "a") as f:
         f.write(f"{datetime.now()}: {msg}\n")
     print(msg)


### PR DESCRIPTION
## Summary
- ensure config directory exists before saving viewerconfig
- create log directory before writing log messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892857b98c4832bb02ce5de9a41b628