### PR TITLE
Enable dynamic mode switching in web UI

### DIFF
--- a/echoview/web/static/script.js
+++ b/echoview/web/static/script.js
@@ -40,6 +40,42 @@ function initCollapsible() {
 }
 window.addEventListener("DOMContentLoaded", initCollapsible);
 
+// ---- Mode section toggling ----
+function showModeSection(dname, mode) {
+  const all = ['random','category','specific_image','mixed','videos','spotify','web_page'];
+  const map = {
+    'random_image': ['random','category'],
+    'specific_image': ['category','specific_image'],
+    'mixed': ['random','mixed'],
+    'videos': ['videos'],
+    'spotify': ['spotify'],
+    'web_page': ['web_page']
+  };
+  const toShow = map[mode] || [];
+  all.forEach(sec => {
+    const el = document.getElementById(`${dname}_${sec}_section`);
+    if (el) el.style.display = toShow.includes(sec) ? 'block' : 'none';
+  });
+  if (mode === 'mixed') {
+    const sec = document.getElementById(`${dname}_mixed_section`);
+    if (sec && !sec.dataset.init) {
+      initMixedUI(dname);
+      sec.dataset.init = '1';
+    }
+  }
+}
+
+function initModeHandlers() {
+  document.querySelectorAll('select[id$="_mode"]').forEach(sel => {
+    const dname = sel.id.replace('_mode','');
+    sel.addEventListener('change', () => {
+      showModeSection(dname, sel.value);
+    });
+    showModeSection(dname, sel.value);
+  });
+}
+document.addEventListener('DOMContentLoaded', initModeHandlers);
+
 // ---- Mixed Folder UI (click to move items) ----
 function initMixedUI(dispName) {
   const searchBox = document.getElementById(dispName + "_search");

--- a/echoview/web/static/style.css
+++ b/echoview/web/static/style.css
@@ -127,6 +127,11 @@ h1, h2, h3, h4, h5, h6 {
   position: relative;
 }
 
+/* Mode sections hidden by default */
+.mode-section {
+  display: none;
+}
+
 /* Table styling */
 table {
   width: 100%;

--- a/echoview/web/templates/index.html
+++ b/echoview/web/templates/index.html
@@ -20,15 +20,16 @@
   <!-- Multi-monitor: one card per display -->
   <form method="POST">
     <input type="hidden" name="action" value="update_displays">
-    <div class="cards-container">
+    <div class="row g-3">
       {% for dname, dcfg in cfg.displays.items() %}
-      <div class="card" style="text-align:center;">
+      <div class="col-12 col-md-6 col-lg-4">
+        <div class="card h-100 text-center">
         <h3>{{ dname }} ({{ monitors[dname].resolution }})</h3>
         <!-- Display Settings for this monitor -->
         <div>
           <!-- Mode -->
           <label>Mode:</label><br>
-          <select name="{{ dname }}_mode">
+          <select name="{{ dname }}_mode" id="{{ dname }}_mode">
             <option value="random_image"   {% if dcfg.mode=="random_image" %}selected{% endif %}>Random Image/GIF</option>
             <option value="specific_image" {% if dcfg.mode=="specific_image" %}selected{% endif %}>Specific Image/GIF</option>
             <option value="mixed"          {% if dcfg.mode=="mixed" %}selected{% endif %}>Mixed (Multiple Folders)</option>
@@ -37,203 +38,206 @@
             <option value="web_page"       {% if dcfg.mode=="web_page" %}selected{% endif %}>Web Page</option>
           </select>
           <br><br>
-          <!-- Fallback Mode (only shown if Spotify mode is selected) -->
-          {% if dcfg.mode == "spotify" %}
-          <label>Fallback Mode:</label><br>
-          <select name="{{ dname }}_fallback_mode">
-            <option value="random_image"   {% if dcfg.fallback_mode=="random_image" %}selected{% endif %}>Random Image/GIF</option>
-            <option value="specific_image" {% if dcfg.fallback_mode=="specific_image" %}selected{% endif %}>Specific Image/GIF</option>
-            <option value="mixed"          {% if dcfg.fallback_mode=="mixed" %}selected{% endif %}>Mixed (Multiple Folders)</option>
-            <option value="none"           {% if dcfg.fallback_mode=="none" %}selected{% endif %}>None</option>
-          </select>
-          <br><br>
-          <!-- Spotify Info Options as inline checkboxes -->
-          <div style="display:flex; flex-wrap:wrap; gap:10px; justify-content:center;">
-            <label style="display:inline-block;">
-              <input type="checkbox" name="{{ dname }}_spotify_show_song" value="1" {% if dcfg.spotify_show_song is not defined or dcfg.spotify_show_song %}checked{% endif %}>
-              Song Title
-            </label>
-            <label style="display:inline-block;">
-              <input type="checkbox" name="{{ dname }}_spotify_show_artist" value="1" {% if dcfg.spotify_show_artist is not defined or dcfg.spotify_show_artist %}checked{% endif %}>
-              Artist
-            </label>
-            <label style="display:inline-block;">
-              <input type="checkbox" name="{{ dname }}_spotify_show_album" value="1" {% if dcfg.spotify_show_album is not defined or dcfg.spotify_show_album %}checked{% endif %}>
-              Album
-            </label>
-            <label style="display:inline-block;">
-              <input type="checkbox" name="{{ dname }}_spotify_show_progress" value="1" {% if dcfg.spotify_show_progress is defined and dcfg.spotify_show_progress %}checked{% endif %}>
-              Live Playback Progress
-            </label>
-            <label style="display:inline-block;">
-              <input type="checkbox" name="{{ dname }}_spotify_negative_font" value="1" {% if dcfg.spotify_negative_font is not defined or dcfg.spotify_negative_font %}checked{% endif %}>
-              Auto Negative Font
-            </label>
+
+          <!-- Spotify Settings -->
+          <div id="{{ dname }}_spotify_section" class="mode-section">
+            <label>Fallback Mode:</label><br>
+            <select name="{{ dname }}_fallback_mode">
+              <option value="random_image"   {% if dcfg.fallback_mode=="random_image" %}selected{% endif %}>Random Image/GIF</option>
+              <option value="specific_image" {% if dcfg.fallback_mode=="specific_image" %}selected{% endif %}>Specific Image/GIF</option>
+              <option value="mixed"          {% if dcfg.fallback_mode=="mixed" %}selected{% endif %}>Mixed (Multiple Folders)</option>
+              <option value="none"           {% if dcfg.fallback_mode=="none" %}selected{% endif %}>None</option>
+            </select>
+            <br><br>
+            <!-- Spotify Info Options as inline checkboxes -->
+            <div style="display:flex; flex-wrap:wrap; gap:10px; justify-content:center;">
+              <label style="display:inline-block;">
+                <input type="checkbox" name="{{ dname }}_spotify_show_song" value="1" {% if dcfg.spotify_show_song is not defined or dcfg.spotify_show_song %}checked{% endif %}>
+                Song Title
+              </label>
+              <label style="display:inline-block;">
+                <input type="checkbox" name="{{ dname }}_spotify_show_artist" value="1" {% if dcfg.spotify_show_artist is not defined or dcfg.spotify_show_artist %}checked{% endif %}>
+                Artist
+              </label>
+              <label style="display:inline-block;">
+                <input type="checkbox" name="{{ dname }}_spotify_show_album" value="1" {% if dcfg.spotify_show_album is not defined or dcfg.spotify_show_album %}checked{% endif %}>
+                Album
+              </label>
+              <label style="display:inline-block;">
+                <input type="checkbox" name="{{ dname }}_spotify_show_progress" value="1" {% if dcfg.spotify_show_progress is defined and dcfg.spotify_show_progress %}checked{% endif %}>
+                Live Playback Progress
+              </label>
+              <label style="display:inline-block;">
+                <input type="checkbox" name="{{ dname }}_spotify_negative_font" value="1" {% if dcfg.spotify_negative_font is not defined or dcfg.spotify_negative_font %}checked{% endif %}>
+                Auto Negative Font
+              </label>
+            </div>
+            <br>
+            <label>Spotify Font Size:</label>
+            <input type="number" name="{{ dname }}_spotify_font_size" value="{{ dcfg.spotify_font_size|default(18) }}" style="width:60px;">
+            <br><br>
+            <!-- Spotify Info Position Dropdown -->
+            <label>Spotify Info Position:</label><br>
+            <select name="{{ dname }}_spotify_info_position">
+              <option value="top-left" {% if dcfg.spotify_info_position=="top-left" %}selected{% endif %}>Top Left</option>
+              <option value="top-center" {% if dcfg.spotify_info_position=="top-center" %}selected{% endif %}>Top Center</option>
+              <option value="top-right" {% if dcfg.spotify_info_position=="top-right" %}selected{% endif %}>Top Right</option>
+              <option value="bottom-left" {% if dcfg.spotify_info_position=="bottom-left" %}selected{% endif %}>Bottom Left</option>
+              <option value="bottom-center" {% if dcfg.spotify_info_position=="bottom-center" or dcfg.spotify_info_position is not defined %}selected{% endif %}>Bottom Center</option>
+              <option value="bottom-right" {% if dcfg.spotify_info_position=="bottom-right" %}selected{% endif %}>Bottom Right</option>
+            </select>
+            <br><br>
+            <!-- New: Progress Bar settings -->
+            <label>Progress Bar Position:</label><br>
+            <select name="{{ dname }}_spotify_progress_position">
+              <option value="above_info" {% if dcfg.spotify_progress_position=="above_info" %}selected{% endif %}>Above Info</option>
+              <option value="below_info" {% if dcfg.spotify_progress_position=="below_info" or dcfg.spotify_progress_position is not defined %}selected{% endif %}>Below Info</option>
+              <option value="top-center" {% if dcfg.spotify_progress_position=="top-center" %}selected{% endif %}>Top Center</option>
+              <option value="bottom-center" {% if dcfg.spotify_progress_position=="bottom-center" %}selected{% endif %}>Bottom Center</option>
+            </select>
+            <br><br>
+            <label>Progress Bar Theme:</label><br>
+            <select name="{{ dname }}_spotify_progress_theme">
+              <option value="dark" {% if dcfg.spotify_progress_theme=="dark" or dcfg.spotify_progress_theme is not defined %}selected{% endif %}>Dark</option>
+              <option value="spotify" {% if dcfg.spotify_progress_theme=="spotify" %}selected{% endif %}>Spotify</option>
+              <option value="coffee" {% if dcfg.spotify_progress_theme=="coffee" %}selected{% endif %}>Coffee</option>
+              <option value="light" {% if dcfg.spotify_progress_theme=="light" %}selected{% endif %}>Light</option>
+            </select>
+            <br><br>
           </div>
-          <br>
-          <label>Spotify Font Size:</label>
-          <input type="number" name="{{ dname }}_spotify_font_size" value="{{ dcfg.spotify_font_size|default(18) }}" style="width:60px;">
-          <br><br>
-          <!-- Spotify Info Position Dropdown -->
-          <label>Spotify Info Position:</label><br>
-          <select name="{{ dname }}_spotify_info_position">
-            <option value="top-left" {% if dcfg.spotify_info_position=="top-left" %}selected{% endif %}>Top Left</option>
-            <option value="top-center" {% if dcfg.spotify_info_position=="top-center" %}selected{% endif %}>Top Center</option>
-            <option value="top-right" {% if dcfg.spotify_info_position=="top-right" %}selected{% endif %}>Top Right</option>
-            <option value="bottom-left" {% if dcfg.spotify_info_position=="bottom-left" %}selected{% endif %}>Bottom Left</option>
-            <option value="bottom-center" {% if dcfg.spotify_info_position=="bottom-center" or dcfg.spotify_info_position is not defined %}selected{% endif %}>Bottom Center</option>
-            <option value="bottom-right" {% if dcfg.spotify_info_position=="bottom-right" %}selected{% endif %}>Bottom Right</option>
-          </select>
-          <br><br>
-          <!-- New: Progress Bar settings -->
-          <label>Progress Bar Position:</label><br>
-          <select name="{{ dname }}_spotify_progress_position">
-            <option value="above_info" {% if dcfg.spotify_progress_position=="above_info" %}selected{% endif %}>Above Info</option>
-            <option value="below_info" {% if dcfg.spotify_progress_position=="below_info" or dcfg.spotify_progress_position is not defined %}selected{% endif %}>Below Info</option>
-            <option value="top-center" {% if dcfg.spotify_progress_position=="top-center" %}selected{% endif %}>Top Center</option>
-            <option value="bottom-center" {% if dcfg.spotify_progress_position=="bottom-center" %}selected{% endif %}>Bottom Center</option>
-          </select>
-          <br><br>
-          <label>Progress Bar Theme:</label><br>
-          <select name="{{ dname }}_spotify_progress_theme">
-            <option value="dark" {% if dcfg.spotify_progress_theme=="dark" or dcfg.spotify_progress_theme is not defined %}selected{% endif %}>Dark</option>
-            <option value="spotify" {% if dcfg.spotify_progress_theme=="spotify" %}selected{% endif %}>Spotify</option>
-            <option value="coffee" {% if dcfg.spotify_progress_theme=="coffee" %}selected{% endif %}>Coffee</option>
-            <option value="light" {% if dcfg.spotify_progress_theme=="light" %}selected{% endif %}>Light</option>
-          </select>
-          <br><br>
-          <!-- Note: The progress bar update interval has been removed from the web page -->
-          {% endif %}
-          <!-- Interval (only for random/mixed) -->
-          {% if dcfg.mode in ["random_image","mixed"] %}
-          <label>Interval (sec):</label><br>
-          <input type="number" name="{{ dname }}_image_interval" value="{{ dcfg.image_interval }}">
-          <br><br>
-          {% endif %}
+
+          <!-- Random/Mixed Settings -->
+          <div id="{{ dname }}_random_section" class="mode-section">
+            <label>Interval (sec):</label><br>
+            <input type="number" name="{{ dname }}_image_interval" value="{{ dcfg.image_interval }}">
+            <br><br>
+            <label>Shuffle?</label><br>
+            <select name="{{ dname }}_shuffle_mode">
+              <option value="yes" {% if dcfg.shuffle_mode %}selected{% endif %}>Yes</option>
+              <option value="no"  {% if not dcfg.shuffle_mode %}selected{% endif %}>No</option>
+            </select>
+            <br><br>
+          </div>
+
           <!-- Rotate -->
           <label>Rotate (degrees):</label><br>
           <input type="number" name="{{ dname }}_rotate" value="{{ dcfg.rotate|default(0) }}">
           <br><br>
-          <!-- Shuffle (only for random/mixed) -->
-          {% if dcfg.mode in ["random_image","mixed"] %}
-          <label>Shuffle?</label><br>
-          <select name="{{ dname }}_shuffle_mode">
-            <option value="yes" {% if dcfg.shuffle_mode %}selected{% endif %}>Yes</option>
-            <option value="no"  {% if not dcfg.shuffle_mode %}selected{% endif %}>No</option>
-          </select>
-          <br><br>
-          {% endif %}
-          <!-- Category (for random/specific) -->
-          {% if dcfg.mode in ["random_image","specific_image"] %}
-          <label>Category (subfolder):</label><br>
-          <select name="{{ dname }}_image_category">
-            <option value="" {% if not dcfg.image_category %}selected{% endif %}>All</option>
-            {% for sf in subfolders %}
-              {% set count = folder_counts[sf] %}
-              <option value="{{ sf }}" {% if dcfg.image_category==sf %}selected{% endif %}>
-                {{ sf }} ({{ count }} files)
-              </option>
-            {% endfor %}
-          </select>
-          <br><br>
-          {% endif %}
-          <!-- Mixed Folders UI -->
-          {% if dcfg.mode == "mixed" %}
-          <label>Multiple Folders (drag to reorder):</label><br>
-          <input type="text" placeholder="Search..." id="{{ dname }}_search" style="width:90%;"><br>
-          <div style="display:flex; gap:10px; margin-top:10px;">
-            <ul id="{{ dname }}_availList" style="flex:1; list-style:none; border:1px solid var(--border-muted); padding:5px;">
+
+          <!-- Category selection for Random/Specific -->
+          <div id="{{ dname }}_category_section" class="mode-section">
+            <label>Category (subfolder):</label><br>
+            <select name="{{ dname }}_image_category">
+              <option value="" {% if not dcfg.image_category %}selected{% endif %}>All</option>
               {% for sf in subfolders %}
-                {% if sf not in dcfg.mixed_folders %}
-                  <li draggable="true" data-folder="{{ sf }}" style="margin:4px; border:1px solid #666; border-radius:4px; cursor:move; padding:4px;">
-                    {{ sf }} ({{ folder_counts[sf] }})
-                  </li>
-                {% endif %}
+                {% set count = folder_counts[sf] %}
+                <option value="{{ sf }}" {% if dcfg.image_category==sf %}selected{% endif %}>
+                  {{ sf }} ({{ count }} files)
+                </option>
               {% endfor %}
-            </ul>
-            <ul id="{{ dname }}_selList" style="flex:1; list-style:none; border:1px solid var(--border-muted); padding:5px;">
-              {% for sf in dcfg.mixed_folders %}
-                  <li draggable="true" data-folder="{{ sf }}" style="margin:4px; border:1px solid #666; border-radius:4px; cursor:move; padding:4px;">
-                    {{ sf }} ({{ folder_counts[sf]|default(0) }})
-                  </li>
-              {% endfor %}
-            </ul>
-          </div>
-          <input type="hidden" name="{{ dname }}_mixed_order" id="{{ dname }}_mixed_order" value="{{ ','.join(dcfg.mixed_folders) }}">
-          <script>
-            document.addEventListener("DOMContentLoaded", function(){
-              initMixedUI("{{ dname }}");
-            });
-          </script>
-          <br>
-          {% endif %}
-          {% if dcfg.mode == "videos" %}
-          <label>Video Category (subfolder):</label><br>
-          <select name="{{ dname }}_video_category">
-            <option value="" {% if not dcfg.video_category %}selected{% endif %}>All</option>
-            {% for sf in subfolders %}
-              <option value="{{ sf }}" {% if dcfg.video_category==sf %}selected{% endif %}>
-                {{ sf }} ({{ folder_counts[sf]|default(0) }})
-              </option>
-            {% endfor %}
-          </select>
-          <br><br>
-          <label>Shuffle Videos?</label><br>
-          <select name="{{ dname }}_shuffle_videos">
-            <option value="yes" {% if dcfg.shuffle_videos %}selected{% endif %}>Yes</option>
-            <option value="no" {% if not dcfg.shuffle_videos %}selected{% endif %}>No</option>
-          </select>
-          <br><br>
-          <label>Mute by Default:</label>
-          <input type="checkbox" name="{{ dname }}_video_mute" id="{{ dname }}_video_mute" class="video-mute" value="1" {% if dcfg.video_mute is not defined or dcfg.video_mute %}checked{% endif %}>
-          <br><br>
-          <div id="{{ dname }}_volume_container">
-            <label>Volume:</label>
-            <input type="number" name="{{ dname }}_video_volume" value="{{ dcfg.video_volume|default(100) }}" min="0" max="100" style="width:60px;">
+            </select>
             <br><br>
           </div>
-          <label>Play to End:</label>
-          <input type="checkbox" name="{{ dname }}_video_play_to_end" id="{{ dname }}_video_play_to_end" class="video-play-to-end" value="1" {% if dcfg.video_play_to_end is not defined or dcfg.video_play_to_end %}checked{% endif %}>
-          <br><br>
-          <div id="{{ dname }}_max_seconds_container">
-            <label>Max play seconds:</label>
-            <input type="number" name="{{ dname }}_video_max_seconds" value="{{ dcfg.video_max_seconds|default(120) }}" style="width:80px;">
+
+          <!-- Mixed Folders UI -->
+          <div id="{{ dname }}_mixed_section" class="mode-section">
+            <label>Multiple Folders (drag to reorder):</label><br>
+            <input type="text" placeholder="Search..." id="{{ dname }}_search" style="width:90%;"><br>
+            <div style="display:flex; gap:10px; margin-top:10px;">
+              <ul id="{{ dname }}_availList" style="flex:1; list-style:none; border:1px solid var(--border-muted); padding:5px;">
+                {% for sf in subfolders %}
+                  {% if sf not in dcfg.mixed_folders %}
+                    <li draggable="true" data-folder="{{ sf }}" style="margin:4px; border:1px solid #666; border-radius:4px; cursor:move; padding:4px;">
+                      {{ sf }} ({{ folder_counts[sf] }})
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+              <ul id="{{ dname }}_selList" style="flex:1; list-style:none; border:1px solid var(--border-muted); padding:5px;">
+                {% for sf in dcfg.mixed_folders %}
+                    <li draggable="true" data-folder="{{ sf }}" style="margin:4px; border:1px solid #666; border-radius:4px; cursor:move; padding:4px;">
+                      {{ sf }} ({{ folder_counts[sf]|default(0) }})
+                    </li>
+                {% endfor %}
+              </ul>
+            </div>
+            <input type="hidden" name="{{ dname }}_mixed_order" id="{{ dname }}_mixed_order" value="{{ ','.join(dcfg.mixed_folders) }}">
+            <br>
           </div>
-          <br>
-          {% endif %}
-          <!-- Specific Image selection -->
-          {% if dcfg.mode == "specific_image" %}
-          <label>Select Image/GIF:</label><br>
-          {% set fileList = display_images[dname] %}
-          {% if fileList and fileList|length > 100 %}
-            <div id="{{ dname }}_lazyContainer" data-files='{{ fileList|tojson }}'>
-              <button type="button" onclick="loadSpecificThumbnails('{{ dname }}')">Show Thumbnails</button>
-            </div>
-          {% else %}
-            {% if fileList and fileList|length > 0 %}
-            <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:10px;">
-              {% for imgpath in fileList %}
-                {% set bn = imgpath.split('/')[-1] %}
-                <label style="text-align:center; cursor:pointer;">
-                  <img src="/thumb/{{ imgpath }}?size=60" loading="lazy" style="width:60px; height:60px; object-fit:cover; border:2px solid #555; border-radius:4px;">
-                  <br>
-                  <input type="radio" name="{{ dname }}_specific_image" value="{{ bn }}"
-                         {% if bn == dcfg.specific_image %}checked{% endif %}>
-                  {{ bn }}
-                </label>
+
+          <!-- Video Settings -->
+          <div id="{{ dname }}_videos_section" class="mode-section">
+            <label>Video Category (subfolder):</label><br>
+            <select name="{{ dname }}_video_category">
+              <option value="" {% if not dcfg.video_category %}selected{% endif %}>All</option>
+              {% for sf in subfolders %}
+                <option value="{{ sf }}" {% if dcfg.video_category==sf %}selected{% endif %}>
+                  {{ sf }} ({{ folder_counts[sf]|default(0) }})
+                </option>
               {% endfor %}
+            </select>
+            <br><br>
+            <label>Shuffle Videos?</label><br>
+            <select name="{{ dname }}_shuffle_videos">
+              <option value="yes" {% if dcfg.shuffle_videos %}selected{% endif %}>Yes</option>
+              <option value="no" {% if not dcfg.shuffle_videos %}selected{% endif %}>No</option>
+            </select>
+            <br><br>
+            <label>Mute by Default:</label>
+            <input type="checkbox" name="{{ dname }}_video_mute" id="{{ dname }}_video_mute" class="video-mute" value="1" {% if dcfg.video_mute is not defined or dcfg.video_mute %}checked{% endif %}>
+            <br><br>
+            <div id="{{ dname }}_volume_container">
+              <label>Volume:</label>
+              <input type="number" name="{{ dname }}_video_volume" value="{{ dcfg.video_volume|default(100) }}" min="0" max="100" style="width:60px;">
+              <br><br>
             </div>
+            <label>Play to End:</label>
+            <input type="checkbox" name="{{ dname }}_video_play_to_end" id="{{ dname }}_video_play_to_end" class="video-play-to-end" value="1" {% if dcfg.video_play_to_end is not defined or dcfg.video_play_to_end %}checked{% endif %}>
+            <br><br>
+            <div id="{{ dname }}_max_seconds_container">
+              <label>Max play seconds:</label>
+              <input type="number" name="{{ dname }}_video_max_seconds" value="{{ dcfg.video_max_seconds|default(120) }}" style="width:80px;">
+            </div>
+            <br>
+          </div>
+
+          <!-- Specific Image selection -->
+          <div id="{{ dname }}_specific_image_section" class="mode-section">
+            <label>Select Image/GIF:</label><br>
+            {% set fileList = display_images[dname] %}
+            {% if fileList and fileList|length > 100 %}
+              <div id="{{ dname }}_lazyContainer" data-files='{{ fileList|tojson }}'>
+                <button type="button" onclick="loadSpecificThumbnails('{{ dname }}')">Show Thumbnails</button>
+              </div>
             {% else %}
-              <p>No images found or category is empty. <a href="{{ url_for('main.upload_media') }}">Upload some?</a></p>
+              {% if fileList and fileList|length > 0 %}
+              <div style="margin-top:10px; display:flex; flex-wrap:wrap; gap:10px;">
+                {% for imgpath in fileList %}
+                  {% set bn = imgpath.split('/')[-1] %}
+                  <label style="text-align:center; cursor:pointer;">
+                    <img src="/thumb/{{ imgpath }}?size=60" loading="lazy" style="width:60px; height:60px; object-fit:cover; border:2px solid #555; border-radius:4px;">
+                    <br>
+                    <input type="radio" name="{{ dname }}_specific_image" value="{{ bn }}"
+                           {% if bn == dcfg.specific_image %}checked{% endif %}>
+                    {{ bn }}
+                  </label>
+                {% endfor %}
+              </div>
+              {% else %}
+                <p>No images found or category is empty. <a href="{{ url_for('main.upload_media') }}">Upload some?</a></p>
+              {% endif %}
             {% endif %}
-          {% endif %}
-          <br>
-          {% endif %}
-          {% if dcfg.mode == "web_page" %}
-          <label>Web URL:</label><br>
-          <input type="text" name="{{ dname }}_web_url" value="{{ dcfg.web_url|default('') }}" style="width:90%;">
-          <br><br>
-          {% endif %}
+            <br>
+          </div>
+
+          <!-- Web Page Settings -->
+          <div id="{{ dname }}_web_page_section" class="mode-section">
+            <label>Web URL:</label><br>
+            <input type="text" name="{{ dname }}_web_url" value="{{ dcfg.web_url|default('') }}" style="width:90%;">
+            <br><br>
+          </div>
+
+        </div>
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
## Summary
- reveal mode-specific settings instantly without reloading using JavaScript toggling
- adopt Bootstrap grid for responsive monitor cards
- hide mode sections by default with CSS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10b269eac832b87d944950fd19581