### PR TITLE
Fix clock overlay and add center placement option

### DIFF
--- a/echoview/config.py
+++ b/echoview/config.py
@@ -27,7 +27,7 @@ load_env()
 # Application Version & Paths
 # ------------------------------------------------------------
 
-APP_VERSION = "1.4.0"  # Add video mode with mpv playback
+APP_VERSION = "1.5.0"  # Next release with clock fixes
 
 VIEWER_HOME = os.environ.get("VIEWER_HOME", "/home/pi/EchoView")
 IMAGE_DIR   = os.environ.get("IMAGE_DIR", "/mnt/EchoViews")

--- a/echoview/viewer.py
+++ b/echoview/viewer.py
@@ -409,7 +409,6 @@ class DisplayWindow(QMainWindow):
                 lbl.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
             else:
                 lbl.setAlignment(Qt.AlignHCenter | Qt.AlignVCenter)
-            lbl.adjustSize()
             h = lbl.sizeHint().height()
             lbl.setFixedHeight(h)
             if "top" in position:
@@ -419,6 +418,7 @@ class DisplayWindow(QMainWindow):
             else:
                 y2 = (container_rect.height() - h) // 2
             lbl.move(margin, y2)
+            lbl.raise_()
             return y2 + h + margin
 
         if hasattr(self, "overlay_config") and self.clock_label.isVisible():
@@ -547,6 +547,9 @@ class DisplayWindow(QMainWindow):
             self.build_local_image_list()
         if self.current_mode == "spotify":
             self.next_image(force=True)
+
+        # Ensure overlay elements are repositioned based on updated settings
+        self.setup_layout()
 
     def build_local_image_list(self):
         mode = self.current_mode

--- a/echoview/web/templates/overlay.html
+++ b/echoview/web/templates/overlay.html
@@ -50,6 +50,10 @@
               {% if monitor_cfg.overlay and monitor_cfg.overlay.clock_position == "top-right" %}selected{% endif %}>
               Top Right
             </option>
+            <option value="center"
+              {% if monitor_cfg.overlay and monitor_cfg.overlay.clock_position == "center" %}selected{% endif %}>
+              Center
+            </option>
             <option value="bottom-left"
               {% if monitor_cfg.overlay and monitor_cfg.overlay.clock_position == "bottom-left" %}selected{% endif %}>
               Bottom Left


### PR DESCRIPTION
## Summary
- Ensure clock overlay spans full width, appears above images, and repositions on config reload
- Add "center" clock position option and raise version to 1.5.0

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a242f05720832bb84dad7517debcc2