### PR TITLE
Fix Spotify progress bar positioning and add font color option

### DIFF
--- a/echoview/utils.py
+++ b/echoview/utils.py
@@ -39,8 +39,8 @@ def init_config():
                     "spotify_show_progress": False,
                     "spotify_progress_position": "bottom-center",   # New: progress bar location setting
                     "spotify_progress_theme": "dark",         # New: progress bar theme option
-                    "spotify_progress_update_interval": 200        # New: update interval in ms
-                    ,
+                    "spotify_progress_update_interval": 200,       # New: update interval in ms
+                    "spotify_font_color": "#FFFFFF",
                     "video_category": "",
                     "shuffle_videos": False,
                     "video_mute": True,

--- a/echoview/viewer.py
+++ b/echoview/viewer.py
@@ -218,9 +218,33 @@ class DisplayWindow(QMainWindow):
         self.spotify_info_label.move(margin, y)
         self.spotify_info_label.raise_()
 
+        self._position_spotify_progress_bar(rect, margin)
+
         if hasattr(self, "overlay_config") and self.clock_label.isVisible():
             pos = self.overlay_config.get("clock_position", "bottom-center")
             self._place_overlay_label(self.clock_label, pos, rect, 0)
+
+    def _position_spotify_progress_bar(self, rect, margin) -> None:
+        if not self.spotify_progress_bar.isVisible():
+            return
+        ppos = self.disp_cfg.get("spotify_progress_position", "bottom-center")
+        pb_height = 10
+        x = self.spotify_info_label.x()
+        y = self.spotify_info_label.y() + self.spotify_info_label.height() + 5
+        width = self.spotify_info_label.width()
+        if ppos == "above_info":
+            y = self.spotify_info_label.y() - pb_height - 5
+        elif ppos == "below_info":
+            y = self.spotify_info_label.y() + self.spotify_info_label.height() + 5
+        elif ppos == "top-center":
+            x, y = margin, margin
+            width = rect.width() - 2 * margin
+        elif ppos == "bottom-center":
+            x = margin
+            y = rect.height() - pb_height - margin
+            width = rect.width() - 2 * margin
+        self.spotify_progress_bar.setGeometry(x, y, width, pb_height)
+        self.spotify_progress_bar.raise_()
 
     def _check_mpv_process(self) -> None:
         """
@@ -381,25 +405,7 @@ class DisplayWindow(QMainWindow):
         margin = 10
 
         # Reposition the Spotify progress bar, if visible
-        if self.spotify_progress_bar.isVisible():
-            ppos = self.disp_cfg.get("spotify_progress_position", "bottom-center")
-            pb_height = 10
-            x = self.spotify_info_label.x()
-            y = self.spotify_info_label.y() + self.spotify_info_label.height() + 5
-            width = self.spotify_info_label.width()
-            if ppos == "above_info":
-                y = self.spotify_info_label.y() - pb_height - 5
-            elif ppos == "below_info":
-                y = self.spotify_info_label.y() + self.spotify_info_label.height() + 5
-            elif ppos == "top-center":
-                x, y = margin, margin
-                width = rect.width() - 2 * margin
-            elif ppos == "bottom-center":
-                x = margin
-                y = rect.height() - pb_height - margin
-                width = rect.width() - 2 * margin
-            self.spotify_progress_bar.setGeometry(x, y, width, pb_height)
-            self.spotify_progress_bar.raise_()
+        self._position_spotify_progress_bar(rect, margin)
 
         if hasattr(self, "overlay_config") and self.clock_label.isVisible():
             pos = self.overlay_config.get("clock_position", "bottom-center")
@@ -701,7 +707,10 @@ class DisplayWindow(QMainWindow):
                     self.spotify_info_label.setFont(font)
                 else:
                     self.spotify_info_label.useDifference = False
-                    self.spotify_info_label.setStyleSheet(f"color: #FFFFFF; font-size: {font_size}px; background: transparent;")
+                    color = self.disp_cfg.get("spotify_font_color", "#FFFFFF")
+                    self.spotify_info_label.setStyleSheet(
+                        f"color: {color}; font-size: {font_size}px; background: transparent;"
+                    )
                 self.spotify_info_label.raise_()
                 self.setup_layout()
             else:

--- a/echoview/web/routes.py
+++ b/echoview/web/routes.py
@@ -697,6 +697,7 @@ def index():
                     except:
                         dcfg["spotify_font_size"] = 18
                     dcfg["spotify_negative_font"] = True if request.form.get(pre + "spotify_negative_font") else False
+                    dcfg["spotify_font_color"] = request.form.get(pre + "spotify_font_color", dcfg.get("spotify_font_color", "#FFFFFF"))
                     dcfg["spotify_info_position"] = request.form.get(pre + "spotify_info_position", dcfg.get("spotify_info_position", "bottom-center"))
                     # New: store the live progress bar option and its settings
                     dcfg["spotify_show_progress"] = True if request.form.get(pre + "spotify_show_progress") else False

--- a/echoview/web/static/script.js
+++ b/echoview/web/static/script.js
@@ -210,6 +210,22 @@ function initVideoMuteToggle() {
 }
 window.addEventListener('DOMContentLoaded', initVideoMuteToggle);
 
+// ---- Spotify font color toggle ----
+function initSpotifyFontColorToggle() {
+  const checkboxes = document.querySelectorAll('.spotify-negative-font');
+  checkboxes.forEach(cb => {
+    const prefix = cb.id.replace('_spotify_negative_font', '');
+    const container = document.getElementById(prefix + '_spotify_font_color_container');
+    const toggle = () => {
+      if (!container) return;
+      container.style.display = cb.checked ? 'none' : 'inline-block';
+    };
+    cb.addEventListener('change', toggle);
+    toggle();
+  });
+}
+window.addEventListener('DOMContentLoaded', initSpotifyFontColorToggle);
+
 // ---- Lazy load thumbnails for specific_image mode ----
 function loadSpecificThumbnails(dispName) {
   const container = document.getElementById(dispName + "_lazyContainer");

--- a/echoview/web/templates/index.html
+++ b/echoview/web/templates/index.html
@@ -68,9 +68,13 @@
                 Live Playback Progress
               </label>
               <label style="display:inline-block;">
-                <input type="checkbox" name="{{ dname }}_spotify_negative_font" value="1" {% if dcfg.spotify_negative_font is not defined or dcfg.spotify_negative_font %}checked{% endif %}>
+                <input type="checkbox" class="spotify-negative-font" id="{{ dname }}_spotify_negative_font" name="{{ dname }}_spotify_negative_font" value="1" {% if dcfg.spotify_negative_font is not defined or dcfg.spotify_negative_font %}checked{% endif %}>
                 Auto Negative Font
               </label>
+              <span id="{{ dname }}_spotify_font_color_container" style="display:inline-block; margin-left:10px;">
+                <label>Font Color:</label>
+                <input type="color" name="{{ dname }}_spotify_font_color" value="{{ dcfg.spotify_font_color|default('#FFFFFF') }}">
+              </span>
             </div>
             <br>
             <label>Spotify Font Size:</label>


### PR DESCRIPTION
## Summary
- ensure Spotify progress bar obeys user-selected position via reusable layout helper
- add configurable Spotify text color when auto negative font is disabled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a26a077b88832ba2755962ac966407