### PR TITLE
Show used and total memory in web UI

### DIFF
--- a/echoview/utils.py
+++ b/echoview/utils.py
@@ -107,6 +107,7 @@ def get_system_stats():
     cpu = psutil.cpu_percent(interval=0.4)
     mem = psutil.virtual_memory()
     mem_used_mb = (mem.total - mem.available) / (1024 * 1024)
+    mem_total_mb = mem.total / (1024 * 1024)
     load1 = 0
     try:
         load1 = os.getloadavg()[0]
@@ -118,7 +119,7 @@ def get_system_stats():
         temp = out
     except:
         pass
-    return (cpu, mem_used_mb, load1, temp)
+    return (cpu, mem_used_mb, mem_total_mb, load1, temp)
 
 def get_storage_stats(path=IMAGE_DIR):
     """Return used and total bytes for the given path."""

--- a/echoview/web/routes.py
+++ b/echoview/web/routes.py
@@ -157,13 +157,14 @@ main_bp = Blueprint("main", __name__, static_folder="static")
 
 @main_bp.route("/stats")
 def stats_json():
-    cpu, mem_mb, load1, temp = get_system_stats()
+    cpu, mem_used_mb, mem_total_mb, load1, temp = get_system_stats()
     used_bytes, total_bytes = get_storage_stats()
     used_human = format_bytes(used_bytes)
     total_human = format_bytes(total_bytes)
     return jsonify({
         "cpu_percent": cpu,
-        "mem_used_mb": round(mem_mb, 1),
+        "mem_used_mb": round(mem_used_mb, 1),
+        "mem_total_mb": round(mem_total_mb, 1),
         "load_1min": round(load1, 2),
         "temp": temp,
         "disk_used": used_human,
@@ -755,9 +756,10 @@ def index():
         img_list.sort()
         display_images[dname] = img_list
 
-    cpu, mem_mb, load1, temp = get_system_stats()
+    cpu, mem_used_mb, mem_total_mb, load1, temp = get_system_stats()
     used_bytes, total_bytes = get_storage_stats()
     disk_line = f"{format_bytes(used_bytes)}/{format_bytes(total_bytes)}"
+    mem_line = f"{round(mem_used_mb, 1)}/{round(mem_total_mb, 1)}"
     host = get_hostname()
     ipaddr = get_ip_address()
     model = get_pi_model()
@@ -796,7 +798,7 @@ def index():
         folder_counts=folder_counts,
         display_images=display_images,
         cpu=cpu,
-        mem_mb=round(mem_mb, 1),
+        mem_line=mem_line,
         load1=round(load1, 2),
         temp=temp,
         disk_usage=disk_line,

--- a/echoview/web/static/script.js
+++ b/echoview/web/static/script.js
@@ -16,7 +16,7 @@ function fetchStats() {
       const tempEl = document.getElementById("stat_temp");
       const diskEl = document.getElementById("stat_disk");
       if (cpuEl)  cpuEl.textContent = data.cpu_percent + "%";
-      if (memEl)  memEl.textContent = data.mem_used_mb + "MB";
+      if (memEl)  memEl.textContent = data.mem_used_mb + "/" + data.mem_total_mb + "MB";
       if (loadEl) loadEl.textContent = data.load_1min;
       if (tempEl) tempEl.textContent = data.temp;
       if (diskEl) diskEl.textContent = data.disk_used + "/" + data.disk_total;

--- a/echoview/web/templates/index.html
+++ b/echoview/web/templates/index.html
@@ -9,7 +9,7 @@
     <div>Hostname: {{ host }}</div>
     <div>IP: {{ ipaddr }}</div>
     <div>CPU: <span id="stat_cpu">{{ cpu }}%</span></div>
-    <div>Mem: <span id="stat_mem">{{ mem_mb }}MB</span></div>
+    <div>Mem: <span id="stat_mem">{{ mem_line }}MB</span></div>
     <div>Temp: <span id="stat_temp">{{ temp }}</span></div>
     <div>Storage: <span id="stat_disk">{{ disk_usage }}</span></div>
     {% if sub_info_line %}


### PR DESCRIPTION
## Summary
- Add total memory value to system stats
- Show memory usage and total capacity on the controller page
- Include total memory in stats JSON and update client JS to render it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb65857bcc832b974013a92e9e579e